### PR TITLE
Allow Template.render() to be called multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ of template tags. You will need to call the `registerTag` API which accepts a
 closure to handle the parsing. You can find examples of the `now`, `if` and
 `for` tags found inside `Node.swift`.
 
+Custom template tags must be registered prior to calling `Template.render` the first time.
+
 The architecture of Stencil along with how to build advanced plugins can be found in the [architecture](ARCHITECTURE.md) document.
 
 ### Comments

--- a/Stencil/Template.swift
+++ b/Stencil/Template.swift
@@ -4,6 +4,7 @@ import PathKit
 /// A class representing a template
 public class Template {
   public let parser:TokenParser
+  private var nodes:[NodeType]? = nil
 
   /// Create a template with the given name inside the main bundle
   public convenience init(named:String) throws {
@@ -42,7 +43,10 @@ public class Template {
 
   /// Render the given template
   public func render(context:Context? = nil) throws -> String {
-    let nodes = try parser.parse()
-    return try renderNodes(nodes, context ?? Context())
+    if nodes == nil {
+        nodes = try parser.parse()
+    }
+    
+    return try renderNodes(nodes!, context ?? Context())
   }
 }


### PR DESCRIPTION
Allow Template.render() to be called multiple times, for the use case where a single template is rendered against multiple Contexts.