### PR TITLE
Add context property to template

### DIFF
--- a/Stencil/Template.swift
+++ b/Stencil/Template.swift
@@ -4,6 +4,7 @@ import PathKit
 /// A class representing a template
 public class Template {
   public let parser:TokenParser
+  public var context:Context? = nil
   private var nodes:[NodeType]? = nil
 
   /// Create a template with the given name inside the given bundle
@@ -39,6 +40,8 @@ public class Template {
         nodes = try parser.parse()
     }
 
-    return try renderNodes(nodes!, context ?? Context())
+    self.context = context
+
+    return try renderNodes(nodes!, self.context ?? Context())
   }
 }


### PR DESCRIPTION
It's a very small change, but it allows context to be stored in the template, meaning that it doesn't always have to be given upon rendering. It's not terribly useful but I need the change for a project I'm working on, maybe others do too :)