### PR TITLE
Cast ForNode values to Array<Any>

### DIFF
--- a/Stencil/Node.swift
+++ b/Stencil/Node.swift
@@ -157,7 +157,7 @@ public class ForNode : NodeType {
   public func render(context: Context) throws -> String {
     let values = try variable.resolve(context)
 
-    if let values = values as? NSArray where values.count > 0 {
+    if let values = values as? [Any] where values.count > 0 {
       return try values.map { item in
         try context.push([loopVariable: item]) {
           try renderNodes(nodes, context)
@@ -232,10 +232,10 @@ public class IfNode : NodeType {
     let result = try variable.resolve(context)
     var truthy = false
 
-    if let result = result as? NSArray {
-      if result.count > 0 {
-        truthy = true
-      }
+    if let result = result as? [Any] {
+      truthy = !result.isEmpty
+    } else if let result = result as? [String:Any] {
+      truthy = !result.isEmpty
     } else if result != nil {
       truthy = true
     }

--- a/Stencil/Variable.swift
+++ b/Stencil/Variable.swift
@@ -87,45 +87,39 @@ public func ==(lhs: Variable, rhs: Variable) -> Bool {
 
 
 func resolveDictionary(current: Any?) -> [String: Any]? {
-  if let dictionary = current as? [String: Any] {
-    return dictionary
-  }
-
-  if let dictionary = current as? [String: AnyObject] {
-    var result: [String: Any] = [:]
-    for (k, v) in dictionary {
-      result[k] = v as Any
-    }
-    return result
-  }
-
-  if let dictionary = current as? NSDictionary {
-    var result: [String: Any] = [:]
-    for (k, v) in dictionary {
-      if let k = k as? String {
-        result[k] = v as Any
+  switch current {
+  case let dictionary as [String: Any]:
+      return dictionary
+  case let dictionary as [String: AnyObject]:
+      var result: [String: Any] = [:]
+      for (k, v) in dictionary {
+          result[k] = v as Any
       }
-    }
-    return result
+      return result
+  case let dictionary as NSDictionary:
+      var result: [String: Any] = [:]
+      for (k, v) in dictionary {
+          if let k = k as? String {
+              result[k] = v as Any
+          }
+      }
+      return result
+  default:
+      return nil
   }
-
-  return nil
 }
 
 func resolveArray(current: Any?) -> [Any]? {
-  if let current = current as? [Any] {
-    return current
+  switch current {
+  case let array as [Any]:
+      return array
+  case let array as [AnyObject]:
+      return array.map { $0 as Any }
+  case let array as NSArray:
+      return array.map { $0 as Any }
+  default:
+      return nil
   }
-
-  if let current = current as? [AnyObject] {
-    return current.map { $0 as Any }
-  }
-
-  if let current = current as? NSArray {
-    return current.map { $0 as Any }
-  }
-
-  return nil
 }
 
 func normalize(current: Any?) -> Any? {

--- a/StencilSpecs/Nodes/ForNodeSpec.swift
+++ b/StencilSpecs/Nodes/ForNodeSpec.swift
@@ -1,5 +1,6 @@
 import Spectre
 import Stencil
+import Foundation
 
 
 describe("ForNode") {
@@ -19,5 +20,25 @@ describe("ForNode") {
     let emptyNodes: [NodeType] = [TextNode(text: "empty")]
     let node = ForNode(variable: "emptyItems", loopVariable: "item", nodes: nodes, emptyNodes: emptyNodes)
     try expect(try node.render(context)) == "empty"
+  }
+
+  $0.it("renders a context variable of type Array<Any>") {
+    let any_context = Context(dictionary: [
+        "items": ([1, 2, 3] as [Any])
+      ])
+
+    let nodes: [NodeType] = [VariableNode(variable: "item")]
+    let node = ForNode(variable: "items", loopVariable: "item", nodes: nodes, emptyNodes: [])
+    try expect(try node.render(any_context)) == "123" 
+  }
+
+  $0.it("renders a context variable of type NSArray") {
+    let nsarray_context = Context(dictionary: [
+        "items": NSArray(array: [1, 2, 3])
+      ])
+
+    let nodes: [NodeType] = [VariableNode(variable: "item")]
+    let node = ForNode(variable: "items", loopVariable: "item", nodes: nodes, emptyNodes: [])
+    try expect(try node.render(nsarray_context)) == "123" 
   }
 }

--- a/StencilSpecs/Nodes/IfNodeSpec.swift
+++ b/StencilSpecs/Nodes/IfNodeSpec.swift
@@ -103,5 +103,11 @@ describe("IfNode") {
       let node = IfNode(variable: "items", trueNodes: [TextNode(text: "true")], falseNodes: [TextNode(text: "false")])
       try expect(try node.render(arrayContext)) == "false"
     }
+
+    $0.it("renders false when Array<Any> variable is empty") {
+      let arrayContext = Context(dictionary: ["items": ([] as [Any])])
+      let node = IfNode(variable: "items", trueNodes: [TextNode(text: "true")], falseNodes: [TextNode(text: "false")])
+      try expect(try node.render(arrayContext)) == "false"
+    }
   }
 }

--- a/StencilSpecs/Nodes/IfNodeSpec.swift
+++ b/StencilSpecs/Nodes/IfNodeSpec.swift
@@ -96,5 +96,12 @@ describe("IfNode") {
       let node = IfNode(variable: "items", trueNodes: [TextNode(text: "true")], falseNodes: [TextNode(text: "false")])
       try expect(try node.render(arrayContext)) == "false"
     }
+
+    $0.it("renders the false when dictionary expression is empty") {
+      let emptyItems = [String:AnyObject]()
+      let arrayContext = Context(dictionary: ["items": emptyItems])
+      let node = IfNode(variable: "items", trueNodes: [TextNode(text: "true")], falseNodes: [TextNode(text: "false")])
+      try expect(try node.render(arrayContext)) == "false"
+    }
   }
 }

--- a/StencilSpecs/Nodes/IfNodeSpec.swift
+++ b/StencilSpecs/Nodes/IfNodeSpec.swift
@@ -104,7 +104,7 @@ describe("IfNode") {
       try expect(try node.render(arrayContext)) == "false"
     }
 
-    $0.it("renders false when Array<Any> variable is empty") {
+    $0.it("renders the false when Array<Any> variable is empty") {
       let arrayContext = Context(dictionary: ["items": ([] as [Any])])
       let node = IfNode(variable: "items", trueNodes: [TextNode(text: "true")], falseNodes: [TextNode(text: "false")])
       try expect(try node.render(arrayContext)) == "false"


### PR DESCRIPTION
If `Context` contains an array of type `Array<Any>` the cast to NSArray in the `render` function of `ForNode` fails, causing the `ForNode` to render nothing. This PR addresses that issue by mapping `values` to an array of type `Array<Any>`.

The following spec illustrates the scenario that would fail before this change:

```swift
  $0.it("renders a context variable of type Array<Any>") {
    let any_context = Context(dictionary: [
        "items": ([1, 2, 3] as [Any])
      ])

    let nodes: [NodeType] = [VariableNode(variable: "item")]
    let node = ForNode(variable: "items", loopVariable: "item", nodes: nodes, emptyNodes: [])
    try expect(try node.render(any_context)) == "123" 
  }
```