### PR TITLE
Allow filter arguments

### DIFF
--- a/Stencil/Filters.swift
+++ b/Stencil/Filters.swift
@@ -8,7 +8,7 @@ func toString(value: Any?) -> String? {
   return nil
 }
 
-func capitalise(value: Any?, arguments: [Any?]) -> Any? {
+func capitalise(value: Any?) -> Any? {
   if let value = toString(value) {
     return value.capitalizedString
   }
@@ -16,7 +16,7 @@ func capitalise(value: Any?, arguments: [Any?]) -> Any? {
   return value
 }
 
-func uppercase(value: Any?, arguments: [Any?]) -> Any? {
+func uppercase(value: Any?) -> Any? {
   if let value = toString(value) {
     return value.uppercaseString
   }
@@ -24,7 +24,7 @@ func uppercase(value: Any?, arguments: [Any?]) -> Any? {
   return value
 }
 
-func lowercase(value: Any?, arguments: [Any?]) -> Any? {
+func lowercase(value: Any?) -> Any? {
   if let value = toString(value) {
     return value.lowercaseString
   }

--- a/Stencil/Filters.swift
+++ b/Stencil/Filters.swift
@@ -8,7 +8,7 @@ func toString(value: Any?) -> String? {
   return nil
 }
 
-func capitalise(value: Any?, args: [String]?) -> Any? {
+func capitalise(value: Any?, args: [Any?]) -> Any? {
   if let value = toString(value) {
     return value.capitalizedString
   }
@@ -16,7 +16,7 @@ func capitalise(value: Any?, args: [String]?) -> Any? {
   return value
 }
 
-func uppercase(value: Any?, args: [String]?) -> Any? {
+func uppercase(value: Any?, args: [Any?]) -> Any? {
   if let value = toString(value) {
     return value.uppercaseString
   }
@@ -24,7 +24,7 @@ func uppercase(value: Any?, args: [String]?) -> Any? {
   return value
 }
 
-func lowercase(value: Any?, args: [String]?) -> Any? {
+func lowercase(value: Any?, args: [Any?]) -> Any? {
   if let value = toString(value) {
     return value.lowercaseString
   }

--- a/Stencil/Filters.swift
+++ b/Stencil/Filters.swift
@@ -8,7 +8,7 @@ func toString(value: Any?) -> String? {
   return nil
 }
 
-func capitalise(value: Any?, args: [Any?]) -> Any? {
+func capitalise(value: Any?, arguments: [Any?]) -> Any? {
   if let value = toString(value) {
     return value.capitalizedString
   }
@@ -16,7 +16,7 @@ func capitalise(value: Any?, args: [Any?]) -> Any? {
   return value
 }
 
-func uppercase(value: Any?, args: [Any?]) -> Any? {
+func uppercase(value: Any?, arguments: [Any?]) -> Any? {
   if let value = toString(value) {
     return value.uppercaseString
   }
@@ -24,7 +24,7 @@ func uppercase(value: Any?, args: [Any?]) -> Any? {
   return value
 }
 
-func lowercase(value: Any?, args: [Any?]) -> Any? {
+func lowercase(value: Any?, arguments: [Any?]) -> Any? {
   if let value = toString(value) {
     return value.lowercaseString
   }

--- a/Stencil/Filters.swift
+++ b/Stencil/Filters.swift
@@ -8,7 +8,7 @@ func toString(value: Any?) -> String? {
   return nil
 }
 
-func capitalise(value: Any?) -> Any? {
+func capitalise(value: Any?, args: [String]?) -> Any? {
   if let value = toString(value) {
     return value.capitalizedString
   }
@@ -16,7 +16,7 @@ func capitalise(value: Any?) -> Any? {
   return value
 }
 
-func uppercase(value: Any?) -> Any? {
+func uppercase(value: Any?, args: [String]?) -> Any? {
   if let value = toString(value) {
     return value.uppercaseString
   }
@@ -24,7 +24,7 @@ func uppercase(value: Any?) -> Any? {
   return value
 }
 
-func lowercase(value: Any?) -> Any? {
+func lowercase(value: Any?, args: [String]?) -> Any? {
   if let value = toString(value) {
     return value.lowercaseString
   }

--- a/Stencil/Lexer.swift
+++ b/Stencil/Lexer.swift
@@ -112,36 +112,3 @@ class Scanner {
     return nil
   }
 }
-
-
-extension String {
-  func findFirstNot(character: Character) -> String.Index? {
-    var index = startIndex
-    while index != endIndex {
-      if character != self[index] {
-        return index
-      }
-      index = index.successor()
-    }
-
-    return nil
-  }
-
-  func findLastNot(character: Character) -> String.Index? {
-    var index = endIndex.predecessor()
-    while index != startIndex {
-      if character != self[index] {
-        return index.successor()
-      }
-      index = index.predecessor()
-    }
-
-    return nil
-  }
-
-  func trim(character: Character) -> String {
-    let first = findFirstNot(character) ?? startIndex
-    let last = findLastNot(character) ?? endIndex
-    return self[first..<last]
-  }
-}

--- a/Stencil/Namespace.swift
+++ b/Stencil/Namespace.swift
@@ -20,9 +20,9 @@ public class Namespace {
   }
 
   private func registerDefaultFilters() {
-    registerFilter("capitalize", filter: capitalise)
-    registerFilter("uppercase", filter: uppercase)
-    registerFilter("lowercase", filter: lowercase)
+    registerFilter("capitalize", filter: Filter(capitalise))
+    registerFilter("uppercase", filter: Filter(uppercase))
+    registerFilter("lowercase", filter: Filter(lowercase))
   }
 
   /// Registers a new template tag

--- a/Stencil/Parser.swift
+++ b/Stencil/Parser.swift
@@ -10,7 +10,7 @@ public func until(tags:[String])(parser:TokenParser, token:Token) -> Bool {
   return false
 }
 
-public typealias Filter = (value: Any?, args: [String]?) throws -> Any?
+public typealias Filter = (value: Any?, args: [Any?]) throws -> Any?
 
 /// A class for parsing an array of tokens and converts them into a collection of Node's
 public class TokenParser {

--- a/Stencil/Parser.swift
+++ b/Stencil/Parser.swift
@@ -10,7 +10,7 @@ public func until(tags:[String])(parser:TokenParser, token:Token) -> Bool {
   return false
 }
 
-public typealias Filter = (value: Any?, args: [Any?]) throws -> Any?
+public typealias Filter = (value: Any?, arguments: [Any?]) throws -> Any?
 
 /// A class for parsing an array of tokens and converts them into a collection of Node's
 public class TokenParser {

--- a/Stencil/Parser.swift
+++ b/Stencil/Parser.swift
@@ -10,7 +10,7 @@ public func until(tags:[String])(parser:TokenParser, token:Token) -> Bool {
   return false
 }
 
-public typealias Filter = Any? throws -> Any?
+public typealias Filter = (value: Any?, args: [String]?) throws -> Any?
 
 /// A class for parsing an array of tokens and converts them into a collection of Node's
 public class TokenParser {

--- a/Stencil/Parser.swift
+++ b/Stencil/Parser.swift
@@ -10,7 +10,18 @@ public func until(tags:[String])(parser:TokenParser, token:Token) -> Bool {
   return false
 }
 
-public typealias Filter = (value: Any?, arguments: [Any?]) throws -> Any?
+public enum Filter {
+    case SimpleFilter((Any?) throws -> Any?)
+    case VariadicFilter((Any?, [Any?]) throws -> Any?)
+    
+    public init(_ function: (Any?) throws -> Any?) {
+        self = .SimpleFilter(function)
+    }
+    
+    public init(_ function: (Any?, [Any?]) throws -> Any?) {
+        self = .VariadicFilter(function)
+    }
+}
 
 /// A class for parsing an array of tokens and converts them into a collection of Node's
 public class TokenParser {

--- a/Stencil/String+Extensions.swift
+++ b/Stencil/String+Extensions.swift
@@ -42,10 +42,6 @@ extension String {
         return self[first..<last]
     }
     
-    var trimQuotationMarks: String {
-        return trim("\"").trim("'")
-    }
-    
     func split(separator: Character, respectQuotes: Bool = false) -> [String] {
         guard respectQuotes == true else {
             return characters.split(separator).map(String.init)

--- a/Stencil/String+Extensions.swift
+++ b/Stencil/String+Extensions.swift
@@ -1,0 +1,91 @@
+//
+//  String+Extensions.swift
+//  Spelt
+//
+//  Created by Niels de Hoog on 24/11/15.
+//  Copyright © 2015 Invisible Pixel. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func findFirstNot(character: Character) -> String.Index? {
+        var index = startIndex
+        while index != endIndex {
+            if character != self[index] {
+                return index
+            }
+            index = index.successor()
+        }
+        
+        return nil
+    }
+    
+    func findLastNot(character: Character) -> String.Index? {
+        var index = endIndex.predecessor()
+        while index != startIndex {
+            if character != self[index] {
+                return index.successor()
+            }
+            index = index.predecessor()
+        }
+        
+        return nil
+    }
+    
+    func trim(character: Character) -> String {
+        guard let first = findFirstNot(character) else {
+            return ""
+        }
+        
+        let last = findLastNot(character) ?? endIndex
+        return self[first..<last]
+    }
+    
+    var trimQuotationMarks: String {
+        return trim("\"").trim("'")
+    }
+    
+    func split(separator: Character, respectQuotes: Bool = false) -> [String] {
+        guard respectQuotes == true else {
+            return characters.split(separator).map(String.init)
+        }
+        
+        // if respectQuotes is true, leave quoted phrases together
+        var word = ""
+        var components: [String] = []
+        var tempSeparator = separator
+        
+        for character in characters {
+            if character == tempSeparator {
+                if character != separator {
+                    word.append(character)
+                }
+                
+                if !word.trim(" ").isEmpty {
+                    components.append(word)
+                    word = ""
+                }
+                
+                tempSeparator = separator
+            }
+            else {
+                if tempSeparator == separator && (character == "'" || character == "\"") {
+                    tempSeparator = character
+                }
+                
+                word.append(character)
+            }
+        }
+        
+        if !word.isEmpty {
+            components.append(word)
+        }
+        
+        return components
+    }
+    
+    func splitAndTrimWhitespace(separator: Character, respectQuotes: Bool = false) -> [String] {
+        return split(separator, respectQuotes: respectQuotes).map({ $0.trim(" ") })
+    }
+}

--- a/Stencil/Tokenizer.swift
+++ b/Stencil/Tokenizer.swift
@@ -1,40 +1,5 @@
 import Foundation
 
-
-/// Split a string by spaces leaving quoted phrases together
-func smartSplit(value: String) -> [String] {
-  var word = ""
-  var separator: Character = " "
-  var components: [String] = []
-
-  for character in value.characters {
-    if character == separator {
-      if separator != " " {
-        word.append(separator)
-      }
-
-      if !word.isEmpty {
-        components.append(word)
-        word = ""
-      }
-
-      separator = " "
-    } else {
-      if separator == " " && (character == "'" || character == "\"") {
-        separator = character
-      }
-      word.append(character)
-    }
-  }
-
-  if !word.isEmpty {
-    components.append(word)
-  }
-
-  return components
-}
-
-
 public enum Token : Equatable {
   /// A token representing a piece of text.
   case Text(value: String)
@@ -52,13 +17,13 @@ public enum Token : Equatable {
   public func components() -> [String] {
     switch self {
     case .Block(let value):
-      return smartSplit(value)
+      return value.splitAndTrimWhitespace(" ", respectQuotes: true)
     case .Variable(let value):
-      return smartSplit(value)
+        return value.splitAndTrimWhitespace(" ", respectQuotes: true)
     case .Text(let value):
-      return smartSplit(value)
+        return value.splitAndTrimWhitespace(" ", respectQuotes: true)
     case .Comment(let value):
-      return smartSplit(value)
+        return value.splitAndTrimWhitespace(" ", respectQuotes: true)
     }
   }
 

--- a/Stencil/Variable.swift
+++ b/Stencil/Variable.swift
@@ -14,7 +14,7 @@ class FilterExpression : Resolvable {
   let variable: Variable
 
   init(token: String, parser: TokenParser) throws {
-    let bits = token.characters.split("|").map({ String($0).trim(" ") })
+    let bits = token.splitAndTrimWhitespace("|")
     if bits.isEmpty {
       filterInvocations = []
       variable = Variable("")

--- a/Stencil/Variable.swift
+++ b/Stencil/Variable.swift
@@ -14,7 +14,7 @@ class FilterExpression : Resolvable {
   let variable: Variable
 
   init(token: String, parser: TokenParser) throws {
-    let bits = token.splitAndTrimWhitespace("|")
+    let bits = token.splitAndTrimWhitespace("|", respectQuotes: true)
     if bits.isEmpty {
       filterInvocations = []
       variable = Variable("")
@@ -147,57 +147,12 @@ func normalize(current: Any?) -> Any? {
 }
 
 func parseFilterComponents(token: String) -> (String, [String]?) {
-    let components = token.splitAndTrimWhitespace(":")
+    let components = token.splitAndTrimWhitespace(":", respectQuotes: true)
     if components.count == 1 {
         return (components[0], nil)
     }
     else  {
         let arguments = components[1].splitAndTrimWhitespace(",").map({ return $0.trimQuotationMarks })
         return (components[0], arguments)
-    }
-}
-
-extension String {
-    var trimQuotationMarks: String {
-        return trim("\"").trim("'")
-    }
-    
-    func splitAndTrimWhitespace(separator: Character) -> [String] {
-        return smartSplit(separator).map({ $0.trim(" ") })
-    }
-    
-    /// Split a string by separator leaving quoted phrases together
-    func smartSplit(separator: Character) -> [String] {
-        var word = ""
-        var components: [String] = []
-        var tempSeparator = separator
-        
-        for character in characters {
-            if character == tempSeparator {
-                if character != separator {
-                    word.append(character)
-                }
-                
-                if !word.isEmpty {
-                    components.append(word)
-                    word = ""
-                }
-                
-                tempSeparator = separator
-            }
-            else {
-                if tempSeparator == separator && (character == "'" || character == "\"") {
-                    tempSeparator = character
-                }
-                
-                word.append(character)
-            }
-        }
-        
-        if !word.isEmpty {
-            components.append(word)
-        }
-        
-        return components
     }
 }

--- a/Stencil/Variable.swift
+++ b/Stencil/Variable.swift
@@ -11,7 +11,7 @@ struct FilterInvocation {
             arguments.append(try variable.resolve(context))
         }
     }
-    return try filter(value: value, args: arguments)
+    return try filter(value: value, arguments: arguments)
   }
 }
 

--- a/StencilSpecs/FilterSpec.swift
+++ b/StencilSpecs/FilterSpec.swift
@@ -7,15 +7,15 @@ describe("template filters") {
 
   $0.it("allows you to register a custom filter") {
     let template = Template(templateString: "{{ name|repeat }}")
-
     let namespace = Namespace()
-    namespace.registerFilter("repeat") { value in
+    let filter = Filter() { value in
       if let value = value as? String {
         return "\(value) \(value)"
       }
 
       return nil
     }
+    namespace.registerFilter("repeat", filter: filter)
 
     let result = try template.render(context, namespace: namespace)
     try expect(result) == "Kyle Kyle"
@@ -24,9 +24,10 @@ describe("template filters") {
   $0.it("allows you to register a custom filter") {
     let template = Template(templateString: "{{ name|repeat }}")
     let namespace = Namespace()
-    namespace.registerFilter("repeat") { value in
+    let filter = Filter() { value in
       throw TemplateSyntaxError("No Repeat")
     }
+    namespace.registerFilter("repeat", filter: filter) 
 
     try expect(try template.render(context, namespace: namespace)).toThrow(TemplateSyntaxError("No Repeat"))
   }
@@ -40,7 +41,7 @@ describe("template filters") {
   $0.it("allows you to pass arguments to filter function") {
     let template = Template(templateString: "{{ name|repeat:3 }}")
     let namespace = Namespace()
-    namespace.registerFilter("repeat") { value, arguments in
+    let filter = Filter() { value, arguments in
       guard let value = value as? String, let repeatCount = arguments.first as? Int else {
         return nil
       }
@@ -48,9 +49,21 @@ describe("template filters") {
       let values: [String] = Array(count: repeatCount, repeatedValue: value)
       return values.joinWithSeparator(" ")
     }
+    namespace.registerFilter("repeat", filter: filter) 
 
     let result = try template.render(context, namespace: namespace)
     try expect(result) == "Kyle Kyle Kyle"
+  }
+
+  $0.it("throws error when passing too many arguments") {
+    let template = Template(templateString: "{{ name|repeat:5 }}")
+    let namespace = Namespace()
+    let filter = Filter() { value in
+      return nil
+    }
+    namespace.registerFilter("repeat", filter: filter)
+
+    try expect(try template.render(context, namespace: namespace)).toThrow(TemplateSyntaxError("Filter 'repeat' expects no arguments. 1 argument(s) received"))
   }
 }
 

--- a/StencilSpecs/FilterSpec.swift
+++ b/StencilSpecs/FilterSpec.swift
@@ -41,7 +41,7 @@ describe("template filters") {
     let template = Template(templateString: "{{ name|repeat:3 }}")
     let namespace = Namespace()
     namespace.registerFilter("repeat") { value, arguments in
-      guard let value = value as? String, let firstArg = arguments.first as? String, let repeatCount = Int(firstArg) else {
+      guard let value = value as? String, let repeatCount = arguments.first as? Int else {
         return nil
       }
       

--- a/StencilSpecs/FilterSpec.swift
+++ b/StencilSpecs/FilterSpec.swift
@@ -36,6 +36,22 @@ describe("template filters") {
     let result = try template.render(Context(dictionary: ["name": "kyle"]))
     try expect(result) == "KYLE"
   }
+
+  $0.it("allows you to pass arguments to filter function") {
+    let template = Template(templateString: "{{ name|repeat:3 }}")
+    let namespace = Namespace()
+    namespace.registerFilter("repeat") { value, args in
+      guard let value = value as? String, let firstArg = args?.first, let repeatCount = Int(firstArg) else {
+        return nil
+      }
+      
+      let values: [String] = Array(count: repeatCount, repeatedValue: value)
+      return values.joinWithSeparator(" ")
+    }
+
+    let result = try template.render(context, namespace: namespace)
+    try expect(result) == "Kyle Kyle Kyle"
+  }
 }
 
 

--- a/StencilSpecs/FilterSpec.swift
+++ b/StencilSpecs/FilterSpec.swift
@@ -40,8 +40,8 @@ describe("template filters") {
   $0.it("allows you to pass arguments to filter function") {
     let template = Template(templateString: "{{ name|repeat:3 }}")
     let namespace = Namespace()
-    namespace.registerFilter("repeat") { value, args in
-      guard let value = value as? String, let firstArg = args?.first, let repeatCount = Int(firstArg) else {
+    namespace.registerFilter("repeat") { value, arguments in
+      guard let value = value as? String, let firstArg = arguments.first as? String, let repeatCount = Int(firstArg) else {
         return nil
       }
       


### PR DESCRIPTION
I would like to propose an addition to custom filters functionality, which allows arguments to be passed to filter functions, just like in [Liquid](https://docs.shopify.com/themes/liquid-documentation/basics). This PR represents a work in progress implementation of that functionality.

Example syntax:

```
{{ post.date | date: "EEE, dd MMM yyyy" }}
```
### Syntax

The syntax I want to propose is as follows:
{{ `variable` | `filter_name`: `arg1`, `arg2` }}

While taking the following rules into account:
- Whitespace is stripped from filter name and/or arguments, unless argument is in quotes
- If argument is in quotes it is treated as a string literal
- If argument is not in quotes it is treated as a variable (which should be resolved before being passed to the function), unless it is a number
### Improvements
- Current implementation treats all arguments as string literals
- Current implementation requires all filter functions to accept arguments. It would be great if that could be optional, and it would be even better if arguments could be passed as actual arguments to the function instead of as an array.

Any comments/suggestions would be appreciated.
