### PR TITLE
Refactor error type to be a enum case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .conche/
 .build/
 Packages/
+xcuserdata

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -8,7 +8,7 @@ public class IncludeNode : NodeType {
     let bits = token.components()
 
     guard bits.count == 2 else {
-      throw TemplateSyntaxError("'include' tag takes one argument, the template file to be included")
+      throw StencilError.TemplateSyntaxError("'include' tag takes one argument, the template file to be included")
     }
 
     return IncludeNode(templateName: Variable(bits[1]))
@@ -20,16 +20,16 @@ public class IncludeNode : NodeType {
 
   public func render(context: Context) throws -> String {
     guard let loader = context["loader"] as? TemplateLoader else {
-      throw TemplateSyntaxError("Template loader not in context")
+      throw StencilError.TemplateSyntaxError("Template loader not in context")
     }
 
     guard let templateName = try self.templateName.resolve(context) as? String else {
-      throw TemplateSyntaxError("'\(self.templateName)' could not be resolved as a string")
+      throw StencilError.TemplateSyntaxError("'\(self.templateName)' could not be resolved as a string")
     }
 
     guard let template = loader.loadTemplate(templateName) else {
       let paths = loader.paths.map { $0.description }.joinWithSeparator(", ")
-      throw TemplateSyntaxError("'\(templateName)' template not found in \(paths)")
+      throw StencilError.TemplateSyntaxError("'\(templateName)' template not found in \(paths)")
     }
 
     return try template.render(context)

--- a/Sources/Inheritence.swift
+++ b/Sources/Inheritence.swift
@@ -34,12 +34,12 @@ class ExtendsNode : NodeType {
     let bits = token.components()
 
     guard bits.count == 2 else {
-      throw TemplateSyntaxError("'extends' takes one argument, the template file to be extended")
+      throw StencilError.TemplateSyntaxError("'extends' takes one argument, the template file to be extended")
     }
 
     let parsedNodes = try parser.parse()
     guard (parsedNodes.any { $0 is ExtendsNode }) == nil else {
-      throw TemplateSyntaxError("'extends' cannot appear more than once in the same template")
+      throw StencilError.TemplateSyntaxError("'extends' cannot appear more than once in the same template")
     }
 
     let blockNodes = parsedNodes.filter { node in node is BlockNode }
@@ -61,16 +61,16 @@ class ExtendsNode : NodeType {
 
   func render(context: Context) throws -> String {
     guard let loader = context["loader"] as? TemplateLoader else {
-      throw TemplateSyntaxError("Template loader not in context")
+      throw StencilError.TemplateSyntaxError("Template loader not in context")
     }
 
     guard let templateName = try self.templateName.resolve(context) as? String else {
-      throw TemplateSyntaxError("'\(self.templateName)' could not be resolved as a string")
+      throw StencilError.TemplateSyntaxError("'\(self.templateName)' could not be resolved as a string")
     }
 
     guard let template = loader.loadTemplate(templateName) else {
       let paths:String = loader.paths.map { $0.description }.joinWithSeparator(", ")
-      throw TemplateSyntaxError("'\(templateName)' template not found in \(paths)")
+      throw StencilError.TemplateSyntaxError("'\(templateName)' template not found in \(paths)")
     }
 
     let blockContext = BlockContext(blocks: blocks)
@@ -90,7 +90,7 @@ class BlockNode : NodeType {
     let bits = token.components()
 
     guard bits.count == 2 else {
-      throw TemplateSyntaxError("'block' tag takes one argument, the template file to be included")
+      throw StencilError.TemplateSyntaxError("'block' tag takes one argument, the template file to be included")
     }
 
     let blockName = bits[1]

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -1,15 +1,7 @@
 import Foundation
 
-public struct TemplateSyntaxError : ErrorType, Equatable, CustomStringConvertible {
-  public let description:String
-
-  public init(_ description:String) {
-    self.description = description
-  }
-}
-
-public func ==(lhs:TemplateSyntaxError, rhs:TemplateSyntaxError) -> Bool {
-  return lhs.description == rhs.description
+public enum StencilError: ErrorType {
+  case TemplateSyntaxError(String)
 }
 
 public protocol NodeType {
@@ -84,7 +76,7 @@ public class NowNode : NodeType {
 
     let components = token.components()
     guard components.count <= 2 else {
-      throw TemplateSyntaxError("'now' tags may only have one argument: the format string `\(token.contents)`.")
+      throw StencilError.TemplateSyntaxError("'now' tags may only have one argument: the format string `\(token.contents)`.")
     }
     if components.count == 2 {
       format = Variable(components[1])
@@ -125,7 +117,7 @@ public class ForNode : NodeType {
     let components = token.components()
 
     guard components.count == 4 && components[2] == "in" else {
-      throw TemplateSyntaxError("'for' statements should use the following 'for x in y' `\(token.contents)`.")
+      throw StencilError.TemplateSyntaxError("'for' statements should use the following 'for x in y' `\(token.contents)`.")
     }
 
     let loopVariable = components[1]
@@ -136,7 +128,7 @@ public class ForNode : NodeType {
     let forNodes = try parser.parse(until(["endfor", "empty"]))
 
     guard let token = parser.nextToken() else {
-      throw TemplateSyntaxError("`endfor` was not found.")
+      throw StencilError.TemplateSyntaxError("`endfor` was not found.")
     }
 
     if token.contents == "empty" {
@@ -179,7 +171,7 @@ public class IfNode : NodeType {
   public class func parse(parser:TokenParser, token:Token) throws -> NodeType {
     let components = token.components()
     guard components.count == 2 else {
-      throw TemplateSyntaxError("'if' statements should use the following 'if condition' `\(token.contents)`.")
+      throw StencilError.TemplateSyntaxError("'if' statements should use the following 'if condition' `\(token.contents)`.")
     }
     let variable = components[1]
     var trueNodes = [NodeType]()
@@ -188,7 +180,7 @@ public class IfNode : NodeType {
     trueNodes = try parser.parse(until(["endif", "else"]))
 
     guard let token = parser.nextToken() else {
-      throw TemplateSyntaxError("`endif` was not found.")
+      throw StencilError.TemplateSyntaxError("`endif` was not found.")
     }
 
     if token.contents == "else" {
@@ -202,7 +194,7 @@ public class IfNode : NodeType {
   public class func parse_ifnot(parser:TokenParser, token:Token) throws -> NodeType {
     let components = token.components()
     guard components.count == 2 else {
-      throw TemplateSyntaxError("'ifnot' statements should use the following 'if condition' `\(token.contents)`.")
+      throw StencilError.TemplateSyntaxError("'ifnot' statements should use the following 'if condition' `\(token.contents)`.")
     }
     let variable = components[1]
     var trueNodes = [NodeType]()
@@ -211,7 +203,7 @@ public class IfNode : NodeType {
     falseNodes = try parser.parse(until(["endif", "else"]))
 
     guard let token = parser.nextToken() else {
-      throw TemplateSyntaxError("`endif` was not found.")
+      throw StencilError.TemplateSyntaxError("`endif` was not found.")
     }
 
     if token.contents == "else" {

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -52,7 +52,7 @@ public class TokenParser {
           if let parser = namespace.tags[tag] {
             nodes.append(try parser(self, token))
           } else {
-            throw TemplateSyntaxError("Unknown template tag '\(tag)'")
+            throw StencilError.TemplateSyntaxError("Unknown template tag '\(tag)'")
           }
         }
       case .Comment:
@@ -80,7 +80,7 @@ public class TokenParser {
       return filter
     }
 
-    throw TemplateSyntaxError("Invalid filter '\(name)'")
+    throw StencilError.TemplateSyntaxError("Invalid filter '\(name)'")
   }
 
   func compileFilter(token: String) throws -> Resolvable {

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -10,7 +10,7 @@ class FilterExpression : Resolvable {
     if bits.isEmpty {
       filters = []
       variable = Variable("")
-      throw TemplateSyntaxError("Variable tags must include at least 1 argument")
+      throw StencilError.TemplateSyntaxError("Variable tags must include at least 1 argument")
     }
 
     variable = Variable(bits[0])

--- a/Stencil.xcodeproj/project.pbxproj
+++ b/Stencil.xcodeproj/project.pbxproj
@@ -1,0 +1,403 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		42C86A9F1C17B2E800735B38 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A921C17B2E800735B38 /* Context.swift */; };
+		42C86AA01C17B2E800735B38 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A931C17B2E800735B38 /* Filters.swift */; };
+		42C86AA11C17B2E800735B38 /* Include.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A941C17B2E800735B38 /* Include.swift */; };
+		42C86AA31C17B2E800735B38 /* Inheritence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A961C17B2E800735B38 /* Inheritence.swift */; };
+		42C86AA41C17B2E800735B38 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A971C17B2E800735B38 /* Lexer.swift */; };
+		42C86AA51C17B2E800735B38 /* Namespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A981C17B2E800735B38 /* Namespace.swift */; };
+		42C86AA61C17B2E800735B38 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A991C17B2E800735B38 /* Node.swift */; };
+		42C86AA71C17B2E800735B38 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A9A1C17B2E800735B38 /* Parser.swift */; };
+		42C86AA81C17B2E800735B38 /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A9B1C17B2E800735B38 /* Template.swift */; };
+		42C86AA91C17B2E800735B38 /* TemplateLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A9C1C17B2E800735B38 /* TemplateLoader.swift */; };
+		42C86AAA1C17B2E800735B38 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A9D1C17B2E800735B38 /* Tokenizer.swift */; };
+		42C86AAB1C17B2E800735B38 /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C86A9E1C17B2E800735B38 /* Variable.swift */; };
+		42C86AC01C17B34200735B38 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42C86ABB1C17B33700735B38 /* PathKit.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		42C86ABA1C17B33700735B38 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 42C86AB51C17B33700735B38 /* PathKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 77DCBACA1A1E2A750054C841;
+			remoteInfo = PathKit;
+		};
+		42C86ABC1C17B33700735B38 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 42C86AB51C17B33700735B38 /* PathKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 77DCBAD51A1E2A750054C841;
+			remoteInfo = PathKitTests;
+		};
+		42C86ABE1C17B33C00735B38 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 42C86AB51C17B33700735B38 /* PathKit.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 77DCBAC91A1E2A750054C841;
+			remoteInfo = PathKit;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		42C86A871C17B2C500735B38 /* Stencil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		42C86A921C17B2E800735B38 /* Context.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Context.swift; path = Sources/Context.swift; sourceTree = SOURCE_ROOT; };
+		42C86A931C17B2E800735B38 /* Filters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Filters.swift; path = Sources/Filters.swift; sourceTree = SOURCE_ROOT; };
+		42C86A941C17B2E800735B38 /* Include.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Include.swift; path = Sources/Include.swift; sourceTree = SOURCE_ROOT; };
+		42C86A951C17B2E800735B38 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Sources/Info.plist; sourceTree = SOURCE_ROOT; };
+		42C86A961C17B2E800735B38 /* Inheritence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Inheritence.swift; path = Sources/Inheritence.swift; sourceTree = SOURCE_ROOT; };
+		42C86A971C17B2E800735B38 /* Lexer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Lexer.swift; path = Sources/Lexer.swift; sourceTree = SOURCE_ROOT; };
+		42C86A981C17B2E800735B38 /* Namespace.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Namespace.swift; path = Sources/Namespace.swift; sourceTree = SOURCE_ROOT; };
+		42C86A991C17B2E800735B38 /* Node.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Node.swift; path = Sources/Node.swift; sourceTree = SOURCE_ROOT; };
+		42C86A9A1C17B2E800735B38 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Parser.swift; path = Sources/Parser.swift; sourceTree = SOURCE_ROOT; };
+		42C86A9B1C17B2E800735B38 /* Template.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Template.swift; path = Sources/Template.swift; sourceTree = SOURCE_ROOT; };
+		42C86A9C1C17B2E800735B38 /* TemplateLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TemplateLoader.swift; path = Sources/TemplateLoader.swift; sourceTree = SOURCE_ROOT; };
+		42C86A9D1C17B2E800735B38 /* Tokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Tokenizer.swift; path = Sources/Tokenizer.swift; sourceTree = SOURCE_ROOT; };
+		42C86A9E1C17B2E800735B38 /* Variable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Variable.swift; path = Sources/Variable.swift; sourceTree = SOURCE_ROOT; };
+		42C86AB51C17B33700735B38 /* PathKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PathKit.xcodeproj; path = ../PathKit/PathKit.xcodeproj; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		42C86A831C17B2C500735B38 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				42C86AC01C17B34200735B38 /* PathKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		42C86A7D1C17B2C500735B38 = {
+			isa = PBXGroup;
+			children = (
+				42C86AB51C17B33700735B38 /* PathKit.xcodeproj */,
+				42C86A891C17B2C500735B38 /* Sources */,
+				42C86A881C17B2C500735B38 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		42C86A881C17B2C500735B38 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				42C86A871C17B2C500735B38 /* Stencil.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		42C86A891C17B2C500735B38 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				42C86A921C17B2E800735B38 /* Context.swift */,
+				42C86A931C17B2E800735B38 /* Filters.swift */,
+				42C86A941C17B2E800735B38 /* Include.swift */,
+				42C86A951C17B2E800735B38 /* Info.plist */,
+				42C86A961C17B2E800735B38 /* Inheritence.swift */,
+				42C86A971C17B2E800735B38 /* Lexer.swift */,
+				42C86A981C17B2E800735B38 /* Namespace.swift */,
+				42C86A991C17B2E800735B38 /* Node.swift */,
+				42C86A9A1C17B2E800735B38 /* Parser.swift */,
+				42C86A9B1C17B2E800735B38 /* Template.swift */,
+				42C86A9C1C17B2E800735B38 /* TemplateLoader.swift */,
+				42C86A9D1C17B2E800735B38 /* Tokenizer.swift */,
+				42C86A9E1C17B2E800735B38 /* Variable.swift */,
+			);
+			name = Sources;
+			path = Stencil;
+			sourceTree = "<group>";
+		};
+		42C86AB61C17B33700735B38 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				42C86ABB1C17B33700735B38 /* PathKit.framework */,
+				42C86ABD1C17B33700735B38 /* PathKitTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		42C86A841C17B2C500735B38 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		42C86A861C17B2C500735B38 /* Stencil */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 42C86A8F1C17B2C500735B38 /* Build configuration list for PBXNativeTarget "Stencil" */;
+			buildPhases = (
+				42C86A821C17B2C500735B38 /* Sources */,
+				42C86A831C17B2C500735B38 /* Frameworks */,
+				42C86A841C17B2C500735B38 /* Headers */,
+				42C86A851C17B2C500735B38 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				42C86ABF1C17B33C00735B38 /* PBXTargetDependency */,
+			);
+			name = Stencil;
+			productName = Stencil;
+			productReference = 42C86A871C17B2C500735B38 /* Stencil.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		42C86A7E1C17B2C500735B38 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = "Johannes Schriewer";
+				TargetAttributes = {
+					42C86A861C17B2C500735B38 = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
+			};
+			buildConfigurationList = 42C86A811C17B2C500735B38 /* Build configuration list for PBXProject "Stencil" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 42C86A7D1C17B2C500735B38;
+			productRefGroup = 42C86A881C17B2C500735B38 /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 42C86AB61C17B33700735B38 /* Products */;
+					ProjectRef = 42C86AB51C17B33700735B38 /* PathKit.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				42C86A861C17B2C500735B38 /* Stencil */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		42C86ABB1C17B33700735B38 /* PathKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = PathKit.framework;
+			remoteRef = 42C86ABA1C17B33700735B38 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		42C86ABD1C17B33700735B38 /* PathKitTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = PathKitTests.xctest;
+			remoteRef = 42C86ABC1C17B33700735B38 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		42C86A851C17B2C500735B38 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		42C86A821C17B2C500735B38 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				42C86AA91C17B2E800735B38 /* TemplateLoader.swift in Sources */,
+				42C86A9F1C17B2E800735B38 /* Context.swift in Sources */,
+				42C86AA51C17B2E800735B38 /* Namespace.swift in Sources */,
+				42C86AA01C17B2E800735B38 /* Filters.swift in Sources */,
+				42C86AA81C17B2E800735B38 /* Template.swift in Sources */,
+				42C86AA31C17B2E800735B38 /* Inheritence.swift in Sources */,
+				42C86AA71C17B2E800735B38 /* Parser.swift in Sources */,
+				42C86AAB1C17B2E800735B38 /* Variable.swift in Sources */,
+				42C86AAA1C17B2E800735B38 /* Tokenizer.swift in Sources */,
+				42C86AA11C17B2E800735B38 /* Include.swift in Sources */,
+				42C86AA41C17B2E800735B38 /* Lexer.swift in Sources */,
+				42C86AA61C17B2E800735B38 /* Node.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		42C86ABF1C17B33C00735B38 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PathKit;
+			targetProxy = 42C86ABE1C17B33C00735B38 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		42C86A8D1C17B2C500735B38 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		42C86A8E1C17B2C500735B38 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		42C86A901C17B2C500735B38 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Sources/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocode.Stencil;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		42C86A911C17B2C500735B38 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Sources/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocode.Stencil;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		42C86A811C17B2C500735B38 /* Build configuration list for PBXProject "Stencil" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				42C86A8D1C17B2C500735B38 /* Debug */,
+				42C86A8E1C17B2C500735B38 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		42C86A8F1C17B2C500735B38 /* Build configuration list for PBXNativeTarget "Stencil" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				42C86A901C17B2C500735B38 /* Debug */,
+				42C86A911C17B2C500735B38 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 42C86A7E1C17B2C500735B38 /* Project object */;
+}

--- a/Stencil.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Stencil.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Stencil.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Stencil.xcodeproj/project.xcworkspace/xcshareddata/Stencil.xcscmblueprint
+++ b/Stencil.xcodeproj/project.xcworkspace/xcshareddata/Stencil.xcscmblueprint
@@ -1,0 +1,37 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "3DA8097D366B6AFDAEA91946C35253AA1EBC780B",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "BE5BDA2E20B3974D449688AB4E7C7C69AA118665" : 0,
+    "E3472B155FC961329A2EA7BFAD3AFAE6EFBD63E5" : 0,
+    "3DA8097D366B6AFDAEA91946C35253AA1EBC780B" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "C3A207A8-B1A4-4D47-B6CA-7C215C3F6DA3",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "BE5BDA2E20B3974D449688AB4E7C7C69AA118665" : "..",
+    "E3472B155FC961329A2EA7BFAD3AFAE6EFBD63E5" : "PathKit\/",
+    "3DA8097D366B6AFDAEA91946C35253AA1EBC780B" : "Stencil\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "Stencil",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Stencil.xcodeproj",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:dunkelstern\/Stencil.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "3DA8097D366B6AFDAEA91946C35253AA1EBC780B"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:dunkelstern\/unchained.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "BE5BDA2E20B3974D449688AB4E7C7C69AA118665"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:dunkelstern\/PathKit.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "E3472B155FC961329A2EA7BFAD3AFAE6EFBD63E5"
+    }
+  ]
+}


### PR DESCRIPTION
This makes error handling easier if you want to specifically catch the `TemplateParseError`

~~~swift
do {
    let t = try Template(path: templatePath)
    do {
        let body = try t.render(context, namespace: nil)
        print("Rendered template: \(body)")
    } catch StencilError.TemplateSyntaxError(let message) {
        print("Template parse error: \(message)")
    }
} catch {
    print("Could not load template \(templatePath)")
}
~~~

Further the `StencilError` enum could be expanded to send back more detailed error messages than just a generic parse error.

(I also added a Xcode project, feel free to skip that)