### PR TITLE
Added `try` to throwing expressions in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ let context = Context(dictionary: [
 ])
 
 do {
-  let template = Template(named: "template.stencil")
-  let rendered = template.render(context)
+  let template = try Template(named: "template.stencil")
+  let rendered = try template.render(context)
   print(rendered)
 } catch {
   print("Failed to render template \(error)")


### PR DESCRIPTION
Both `Template(named: "template.stencil")` and `Template(named: "template.stencil")` throw but were not preceded by `try`. This usage example, in it's current form, triggers compiler errors.