### PR TITLE
Added support for swift 3.0 (DEVELOPMENT-SNAPSHOT-2016-03-24-a).

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
   name: "Stencil",
   dependencies: [
-    .Package(url: "https://github.com/kylef/PathKit.git", majorVersion: 0, minor: 6),
+    .Package(url: "https://github.com/ratranqu/PathKit.git", majorVersion: 0, minor: 6),
   ],
   testDependencies: [
     .Package(url: "https://github.com/kylef/spectre-build", majorVersion: 0),

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -17,11 +17,19 @@ public class Context {
   public subscript(key: String) -> Any? {
     /// Retrieves a variable's value, starting at the current context and going upwards
     get {
+        #if !swift(>=3.0)
       for dictionary in Array(dictionaries.reverse()) {
         if let value = dictionary[key] {
           return value
         }
-      }
+            }
+        #else
+            for dictionary in Array(dictionaries.reversed()) {
+            if let value = dictionary[key] {
+            return value
+            }
+            }
+        #endif
 
       return nil
     }

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -2,7 +2,7 @@
 public class Context {
   var dictionaries: [[String: Any]]
   let namespace: Namespace
-
+  
   /// Initialise a Context with an optional dictionary and optional namespace
   public init(dictionary: [String: Any]? = nil, namespace: Namespace = Namespace()) {
     if let dictionary = dictionary {
@@ -10,30 +10,27 @@ public class Context {
     } else {
       dictionaries = []
     }
-
+    
     self.namespace = namespace
   }
-
+  
   public subscript(key: String) -> Any? {
     /// Retrieves a variable's value, starting at the current context and going upwards
     get {
-        #if !swift(>=3.0)
-      for dictionary in Array(dictionaries.reverse()) {
+      #if !swift(>=3.0)
+        let dictionaries = Array(self.dictionaries.reverse())
+      #else
+        let dictionaries = Array(self.dictionaries.reversed())
+      #endif
+      for dictionary in dictionaries {
         if let value = dictionary[key] {
           return value
         }
-            }
-        #else
-            for dictionary in Array(dictionaries.reversed()) {
-            if let value = dictionary[key] {
-            return value
-            }
-            }
-        #endif
-
+      }
+      
       return nil
     }
-
+    
     /// Set a variable in the current context, deleting the variable if it's nil
     set(value) {
       if let dictionary = dictionaries.popLast() {
@@ -43,17 +40,17 @@ public class Context {
       }
     }
   }
-
+  
   /// Push a new level into the Context
   private func push(dictionary: [String: Any]? = nil) {
     dictionaries.append(dictionary ?? [:])
   }
-
+  
   /// Pop the last level off of the Context
   private func pop() -> [String: Any]? {
     return dictionaries.popLast()
   }
-
+  
   /// Push a new level onto the context for the duration of the execution of the given closure
   public func push<Result>(dictionary: [String: Any]? = nil, @noescape closure: (() throws -> Result)) rethrows -> Result {
     push(dictionary)

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -3,72 +3,72 @@ public class ForNode : NodeType {
   let loopVariable:String
   let nodes:[NodeType]
   let emptyNodes: [NodeType]
-
+  
   public class func parse(parser:TokenParser, token:Token) throws -> NodeType {
     let components = token.components()
-
+    
     guard components.count == 4 && components[2] == "in" else {
       throw TemplateSyntaxError("'for' statements should use the following 'for x in y' `\(token.contents)`.")
     }
-
+    
     let loopVariable = components[1]
     let variable = components[3]
-
+    
     var emptyNodes = [NodeType]()
-
+    
     let forNodes = try parser.parse(until(["endfor", "empty"]))
-
+    
     guard let token = parser.nextToken() else {
       throw TemplateSyntaxError("`endfor` was not found.")
     }
-
+    
     if token.contents == "empty" {
       emptyNodes = try parser.parse(until(["endfor"]))
       parser.nextToken()
     }
-
+    
     return ForNode(variable: variable, loopVariable: loopVariable, nodes: forNodes, emptyNodes:emptyNodes)
   }
-
+  
   public init(variable:String, loopVariable:String, nodes:[NodeType], emptyNodes:[NodeType]) {
     self.variable = Variable(variable)
     self.loopVariable = loopVariable
     self.nodes = nodes
     self.emptyNodes = emptyNodes
   }
-
+  
   public func render(context: Context) throws -> String {
     let values = try variable.resolve(context)
-
+    
     if let values = values as? [Any] where values.count > 0 {
       let count = values.count
-        #if !swift(>=3.0)
+      #if !swift(>=3.0)
         return try values.enumerate().map { index, item in
-            let forContext: [String: Any] = [
-                                                "first": index == 0,
-                                                "last": index == (count - 1),
-                                                "counter": index + 1,
-                                                ]
-            
-            return try context.push([loopVariable: item, "forloop": forContext]) {
-                try renderNodes(nodes, context)
-            }
-            }.joinWithSeparator("")
-        #else
+        let forContext: [String: Any] = [
+        "first": index == 0,
+        "last": index == (count - 1),
+        "counter": index + 1,
+        ]
+        
+        return try context.push([loopVariable: item, "forloop": forContext]) {
+        try renderNodes(nodes, context)
+        }
+        }.joinWithSeparator("")
+      #else
         return try values.enumerated().map { index, item in
-                let forContext: [String: Any] = [
-                                                    "first": index == 0,
-                                                    "last": index == (count - 1),
-                                                    "counter": index + 1,
-                                                    ]
-                
-                return try context.push([loopVariable: item, "forloop": forContext]) {
-                    try renderNodes(nodes, context)
-                }
-    }.joined(separator:"")
-    #endif
+          let forContext: [String: Any] = [
+                                            "first": index == 0,
+                                            "last": index == (count - 1),
+                                            "counter": index + 1,
+                                            ]
+          
+          return try context.push([loopVariable: item, "forloop": forContext]) {
+            try renderNodes(nodes, context)
+          }
+          }.joined(separator:"")
+      #endif
     }
-
+    
     return try context.push {
       try renderNodes(emptyNodes, context)
     }

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -42,17 +42,31 @@ public class ForNode : NodeType {
 
     if let values = values as? [Any] where values.count > 0 {
       let count = values.count
-      return try values.enumerate().map { index, item in
-        let forContext: [String: Any] = [
-          "first": index == 0,
-          "last": index == (count - 1),
-          "counter": index + 1,
-        ]
-
-        return try context.push([loopVariable: item, "forloop": forContext]) {
-          try renderNodes(nodes, context)
-        }
-      }.joinWithSeparator("")
+        #if !swift(>=3.0)
+        return try values.enumerate().map { index, item in
+            let forContext: [String: Any] = [
+                                                "first": index == 0,
+                                                "last": index == (count - 1),
+                                                "counter": index + 1,
+                                                ]
+            
+            return try context.push([loopVariable: item, "forloop": forContext]) {
+                try renderNodes(nodes, context)
+            }
+            }.joinWithSeparator("")
+        #else
+        return try values.enumerated().map { index, item in
+                let forContext: [String: Any] = [
+                                                    "first": index == 0,
+                                                    "last": index == (count - 1),
+                                                    "counter": index + 1,
+                                                    ]
+                
+                return try context.push([loopVariable: item, "forloop": forContext]) {
+                    try renderNodes(nodes, context)
+                }
+    }.joined(separator:"")
+    #endif
     }
 
     return try context.push {

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -28,7 +28,11 @@ public class IncludeNode : NodeType {
     }
 
     guard let template = loader.loadTemplate(templateName) else {
+        #if !swift(>=3.0)
       let paths = loader.paths.map { $0.description }.joinWithSeparator(", ")
+        #else
+            let paths = loader.paths.map { $0.description }.joined(separator:", ")
+        #endif
       throw TemplateSyntaxError("'\(templateName)' template not found in \(paths)")
     }
 

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -3,39 +3,39 @@ import PathKit
 
 public class IncludeNode : NodeType {
   public let templateName: Variable
-
+  
   public class func parse(parser: TokenParser, token: Token) throws -> NodeType {
     let bits = token.components()
-
+    
     guard bits.count == 2 else {
       throw TemplateSyntaxError("'include' tag takes one argument, the template file to be included")
     }
-
+    
     return IncludeNode(templateName: Variable(bits[1]))
   }
-
+  
   public init(templateName: Variable) {
     self.templateName = templateName
   }
-
+  
   public func render(context: Context) throws -> String {
     guard let loader = context["loader"] as? TemplateLoader else {
       throw TemplateSyntaxError("Template loader not in context")
     }
-
+    
     guard let templateName = try self.templateName.resolve(context) as? String else {
       throw TemplateSyntaxError("'\(self.templateName)' could not be resolved as a string")
     }
-
+    
     guard let template = loader.loadTemplate(templateName) else {
-        #if !swift(>=3.0)
-      let paths = loader.paths.map { $0.description }.joinWithSeparator(", ")
-        #else
-            let paths = loader.paths.map { $0.description }.joined(separator:", ")
-        #endif
+      #if !swift(>=3.0)
+        let paths = loader.paths.map { $0.description }.joinWithSeparator(", ")
+      #else
+        let paths = loader.paths.map { $0.description }.joined(separator:", ")
+      #endif
       throw TemplateSyntaxError("'\(templateName)' template not found in \(paths)")
     }
-
+    
     return try template.render(context)
   }
 }

--- a/Sources/Inheritence.swift
+++ b/Sources/Inheritence.swift
@@ -1,3 +1,11 @@
+
+
+#if !swift(>=3.0)
+    typealias Collection = CollectionType
+    
+#endif
+
+
 class BlockContext {
   class var contextKey: String { return "block_context" }
 
@@ -8,12 +16,17 @@ class BlockContext {
   }
 
   func pop(blockName: String) -> BlockNode? {
+    #if !swift(>=3.0)
     return blocks.removeValueForKey(blockName)
+    #else
+    return blocks.removeValue(forKey:blockName)
+    #endif
   }
 }
 
 
-extension CollectionType {
+extension Collection {
+    #if !swift(>=3.0)
   func any(closure: Generator.Element -> Bool) -> Generator.Element? {
     for element in self {
       if closure(element) {
@@ -23,6 +36,17 @@ extension CollectionType {
 
     return nil
   }
+    #else
+    func any(closure: Iterator.Element -> Bool) -> Iterator.Element? {
+        for element in self {
+            if closure(element) {
+                return element
+            }
+        }
+        
+        return nil
+    }
+    #endif
 }
 
 
@@ -69,7 +93,11 @@ class ExtendsNode : NodeType {
     }
 
     guard let template = loader.loadTemplate(templateName) else {
+    #if !swift(>=3.0)
       let paths:String = loader.paths.map { $0.description }.joinWithSeparator(", ")
+    #else
+        let paths:String = loader.paths.map { $0.description }.joined(separator:", ")
+    #endif
       throw TemplateSyntaxError("'\(templateName)' template not found in \(paths)")
     }
 

--- a/Sources/Inheritence.swift
+++ b/Sources/Inheritence.swift
@@ -1,106 +1,106 @@
 
 
 #if !swift(>=3.0)
-    typealias Collection = CollectionType
-    
+  typealias Collection = CollectionType
+  
 #endif
 
 
 class BlockContext {
   class var contextKey: String { return "block_context" }
-
+  
   var blocks: [String:BlockNode]
-
+  
   init(blocks: [String:BlockNode]) {
     self.blocks = blocks
   }
-
+  
   func pop(blockName: String) -> BlockNode? {
     #if !swift(>=3.0)
-    return blocks.removeValueForKey(blockName)
+      return blocks.removeValueForKey(blockName)
     #else
-    return blocks.removeValue(forKey:blockName)
+      return blocks.removeValue(forKey:blockName)
     #endif
   }
 }
 
 
 extension Collection {
-    #if !swift(>=3.0)
+  #if !swift(>=3.0)
   func any(closure: Generator.Element -> Bool) -> Generator.Element? {
+    for element in self {
+      if closure(element) {
+      return element
+      }
+    }
+  
+    return nil
+  }
+  #else
+  func any(closure: Iterator.Element -> Bool) -> Iterator.Element? {
     for element in self {
       if closure(element) {
         return element
       }
     }
-
+    
     return nil
   }
-    #else
-    func any(closure: Iterator.Element -> Bool) -> Iterator.Element? {
-        for element in self {
-            if closure(element) {
-                return element
-            }
-        }
-        
-        return nil
-    }
-    #endif
+  #endif
 }
 
 
 class ExtendsNode : NodeType {
   let templateName: Variable
   let blocks: [String:BlockNode]
-
+  
   class func parse(parser: TokenParser, token: Token) throws -> NodeType {
     let bits = token.components()
-
+    
     guard bits.count == 2 else {
       throw TemplateSyntaxError("'extends' takes one argument, the template file to be extended")
     }
-
+    
     let parsedNodes = try parser.parse()
     guard (parsedNodes.any { $0 is ExtendsNode }) == nil else {
       throw TemplateSyntaxError("'extends' cannot appear more than once in the same template")
     }
-
+    
     let blockNodes = parsedNodes.filter { node in node is BlockNode }
-
+    
     let nodes = blockNodes.reduce([String:BlockNode]()) { (accumulator, node:NodeType) -> [String:BlockNode] in
       let node = (node as! BlockNode)
       var dict = accumulator
       dict[node.name] = node
       return dict
     }
-
+    
     return ExtendsNode(templateName: Variable(bits[1]), blocks: nodes)
   }
-
+  
   init(templateName: Variable, blocks: [String: BlockNode]) {
     self.templateName = templateName
     self.blocks = blocks
   }
-
+  
   func render(context: Context) throws -> String {
     guard let loader = context["loader"] as? TemplateLoader else {
       throw TemplateSyntaxError("Template loader not in context")
     }
-
+    
     guard let templateName = try self.templateName.resolve(context) as? String else {
       throw TemplateSyntaxError("'\(self.templateName)' could not be resolved as a string")
     }
-
+    
     guard let template = loader.loadTemplate(templateName) else {
-    #if !swift(>=3.0)
-      let paths:String = loader.paths.map { $0.description }.joinWithSeparator(", ")
-    #else
+      #if !swift(>=3.0)
+        let paths:String = loader.paths.map { $0.description }.joinWithSeparator(", ")
+      #else
         let paths:String = loader.paths.map { $0.description }.joined(separator:", ")
-    #endif
+      #endif
       throw TemplateSyntaxError("'\(templateName)' template not found in \(paths)")
     }
-
+    
     let blockContext = BlockContext(blocks: blocks)
     return try context.push([BlockContext.contextKey: blockContext]) {
       return try template.render(context)
@@ -112,30 +112,30 @@ class ExtendsNode : NodeType {
 class BlockNode : NodeType {
   let name: String
   let nodes: [NodeType]
-
+  
   class func parse(parser: TokenParser, token: Token) throws -> NodeType {
     let bits = token.components()
-
+    
     guard bits.count == 2 else {
       throw TemplateSyntaxError("'block' tag takes one argument, the template file to be included")
     }
-
+    
     let blockName = bits[1]
     let nodes = try parser.parse(until(["endblock"]))
     parser.nextToken()
     return BlockNode(name:blockName, nodes:nodes)
   }
-
+  
   init(name: String, nodes: [NodeType]) {
     self.name = name
     self.nodes = nodes
   }
-
+  
   func render(context: Context) throws -> String {
     if let blockContext = context[BlockContext.contextKey] as? BlockContext, node = blockContext.pop(name) {
       return try node.render(context)
     }
-
+    
     return try renderNodes(nodes, context)
   }
 }

--- a/Sources/Namespace.swift
+++ b/Sources/Namespace.swift
@@ -1,44 +1,44 @@
 public class Namespace {
   public typealias TagParser = (TokenParser, Token) throws -> NodeType
-
+  
   var tags = [String: TagParser]()
   var filters = [String: Filter]()
-
+  
   public init() {
     registerDefaultTags()
     registerDefaultFilters()
   }
-
+  
   private func registerDefaultTags() {
     registerTag("for", parser: ForNode.parse)
     registerTag("if", parser: IfNode.parse)
     registerTag("ifnot", parser: IfNode.parse_ifnot)
-#if !os(Linux)
-    registerTag("now", parser: NowNode.parse)
-#endif
+    #if !os(Linux)
+      registerTag("now", parser: NowNode.parse)
+    #endif
     registerTag("include", parser: IncludeNode.parse)
     registerTag("extends", parser: ExtendsNode.parse)
     registerTag("block", parser: BlockNode.parse)
   }
-
+  
   private func registerDefaultFilters() {
     registerFilter("capitalize", filter: capitalise)
     registerFilter("uppercase", filter: uppercase)
     registerFilter("lowercase", filter: lowercase)
   }
-
+  
   /// Registers a new template tag
   public func registerTag(name: String, parser: TagParser) {
     tags[name] = parser
   }
-
+  
   /// Registers a simple template tag with a name and a handler
   public func registerSimpleTag(name: String, handler: Context throws -> String) {
     registerTag(name, parser: { parser, token in
       return SimpleNode(handler: handler)
     })
   }
-
+  
   /// Registers a template filter with the given name
   public func registerFilter(name: String, filter: Filter) {
     filters[name] = filter

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 #if !swift(>=3.0)
-    typealias ErrorProtocol = ErrorType
+  typealias ErrorProtocol = ErrorType
 #endif
 
 
 public struct TemplateSyntaxError : ErrorProtocol, Equatable, CustomStringConvertible {
   public let description:String
-
+  
   public init(_ description:String) {
     self.description = description
   }
@@ -27,20 +27,20 @@ public protocol NodeType {
 
 /// Render the collection of nodes in the given context
 public func renderNodes(nodes:[NodeType], _ context:Context) throws -> String {
-    #if !swift(>=3.0)
+  #if !swift(>=3.0)
     return try nodes.map { try $0.render(context) }.joinWithSeparator("")
-    #else
-        return try nodes.map { try $0.render(context) }.joined(separator:"")
-    #endif
+  #else
+    return try nodes.map { try $0.render(context) }.joined(separator:"")
+  #endif
 }
 
 public class SimpleNode : NodeType {
   let handler:Context throws -> String
-
+  
   public init(handler:Context throws -> String) {
     self.handler = handler
   }
-
+  
   public func render(context: Context) throws -> String {
     return try handler(context)
   }
@@ -49,11 +49,11 @@ public class SimpleNode : NodeType {
 
 public class TextNode : NodeType {
   public let text:String
-
+  
   public init(text:String) {
     self.text = text
   }
-
+  
   public func render(context:Context) throws -> String {
     return self.text
   }
@@ -67,18 +67,18 @@ public protocol Resolvable {
 
 public class VariableNode : NodeType {
   public let variable: Resolvable
-
+  
   public init(variable: Resolvable) {
     self.variable = variable
   }
-
+  
   public init(variable: String) {
     self.variable = Variable(variable)
   }
-
+  
   public func render(context: Context) throws -> String {
     let result = try variable.resolve(context)
-
+    
     if let result = result as? String {
       return result
     } else if let result = result as? CustomStringConvertible {
@@ -86,7 +86,7 @@ public class VariableNode : NodeType {
     } else if let result = result as? NSObject {
       return result.description
     }
-
+    
     return ""
   }
 }

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -1,7 +1,11 @@
 import Foundation
 
+#if !swift(>=3.0)
+    typealias ErrorProtocol = ErrorType
+#endif
 
-public struct TemplateSyntaxError : ErrorType, Equatable, CustomStringConvertible {
+
+public struct TemplateSyntaxError : ErrorProtocol, Equatable, CustomStringConvertible {
   public let description:String
 
   public init(_ description:String) {
@@ -23,7 +27,11 @@ public protocol NodeType {
 
 /// Render the collection of nodes in the given context
 public func renderNodes(nodes:[NodeType], _ context:Context) throws -> String {
-  return try nodes.map { try $0.render(context) }.joinWithSeparator("")
+    #if !swift(>=3.0)
+    return try nodes.map { try $0.render(context) }.joinWithSeparator("")
+    #else
+        return try nodes.map { try $0.render(context) }.joined(separator:"")
+    #endif
 }
 
 public class SimpleNode : NodeType {

--- a/Sources/NowTag.swift
+++ b/Sources/NowTag.swift
@@ -1,47 +1,47 @@
 #if !os(Linux)
-import Foundation
-
-
-public class NowNode : NodeType {
-  public let format:Variable
-
-  public class func parse(parser:TokenParser, token:Token) throws -> NodeType {
-    var format:Variable?
-
-    let components = token.components()
-    guard components.count <= 2 else {
-      throw TemplateSyntaxError("'now' tags may only have one argument: the format string `\(token.contents)`.")
+  import Foundation
+  
+  
+  public class NowNode : NodeType {
+    public let format:Variable
+    
+    public class func parse(parser:TokenParser, token:Token) throws -> NodeType {
+      var format:Variable?
+      
+      let components = token.components()
+      guard components.count <= 2 else {
+        throw TemplateSyntaxError("'now' tags may only have one argument: the format string `\(token.contents)`.")
+      }
+      if components.count == 2 {
+        format = Variable(components[1])
+      }
+      
+      return NowNode(format:format)
     }
-    if components.count == 2 {
-      format = Variable(components[1])
+    
+    public init(format:Variable?) {
+      self.format = format ?? Variable("\"yyyy-MM-dd 'at' HH:mm\"")
     }
-
-    return NowNode(format:format)
-  }
-
-  public init(format:Variable?) {
-    self.format = format ?? Variable("\"yyyy-MM-dd 'at' HH:mm\"")
-  }
-
-  public func render(context: Context) throws -> String {
-    let date = NSDate()
-    let format = try self.format.resolve(context)
-    var formatter:NSDateFormatter?
-
-    if let format = format as? NSDateFormatter {
-      formatter = format
-    } else if let format = format as? String {
-      formatter = NSDateFormatter()
-      formatter!.dateFormat = format
-    } else {
-      return ""
-    }
-
-    #if !swift(>=3.0)
-    return formatter!.stringFromDate(date)
-    #else
+    
+    public func render(context: Context) throws -> String {
+      let date = NSDate()
+      let format = try self.format.resolve(context)
+      var formatter:NSDateFormatter?
+      
+      if let format = format as? NSDateFormatter {
+        formatter = format
+      } else if let format = format as? String {
+        formatter = NSDateFormatter()
+        formatter!.dateFormat = format
+      } else {
+        return ""
+      }
+      
+      #if !swift(>=3.0)
+        return formatter!.stringFromDate(date)
+      #else
         return formatter!.string(from:date)
-    #endif
+      #endif
     }
-}
+  }
 #endif

--- a/Sources/NowTag.swift
+++ b/Sources/NowTag.swift
@@ -37,7 +37,11 @@ public class NowNode : NodeType {
       return ""
     }
 
+    #if !swift(>=3.0)
     return formatter!.stringFromDate(date)
-  }
+    #else
+        return formatter!.string(from:date)
+    #endif
+    }
 }
 #endif

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -7,7 +7,7 @@ public func until(tags: [String]) -> ((TokenParser, Token) -> Bool) {
         }
       }
     }
-
+    
     return false
   }
 }
@@ -17,26 +17,26 @@ public typealias Filter = Any? throws -> Any?
 /// A class for parsing an array of tokens and converts them into a collection of Node's
 public class TokenParser {
   public typealias TagParser = (TokenParser, Token) throws -> NodeType
-
+  
   private var tokens: [Token]
   private let namespace: Namespace
-
+  
   public init(tokens: [Token], namespace: Namespace) {
     self.tokens = tokens
     self.namespace = namespace
   }
-
+  
   /// Parse the given tokens into nodes
   public func parse() throws -> [NodeType] {
     return try parse(nil)
   }
-
+  
   public func parse(parse_until:((parser:TokenParser, token:Token) -> (Bool))?) throws -> [NodeType] {
     var nodes = [NodeType]()
-
+    
     while tokens.count > 0 {
       let token = nextToken()!
-
+      
       switch token {
       case .Text(let text):
         nodes.append(TextNode(text: text))
@@ -44,12 +44,12 @@ public class TokenParser {
         nodes.append(VariableNode(variable: try compileFilter(token.contents)))
       case .Block:
         let tag = token.components().first
-
+        
         if let parse_until = parse_until where parse_until(parser: self, token: token) {
           prependToken(token)
           return nodes
         }
-
+        
         if let tag = tag {
           if let parser = namespace.tags[tag] {
             nodes.append(try parser(self, token))
@@ -61,39 +61,39 @@ public class TokenParser {
         continue
       }
     }
-
+    
     return nodes
   }
-
+  
   public func nextToken() -> Token? {
     if tokens.count > 0 {
-        #if !swift(>=3.0)
-      return tokens.removeAtIndex(0)
-        #else
-            return tokens.remove(at:0)
-        #endif
+      #if !swift(>=3.0)
+        return tokens.removeAtIndex(0)
+      #else
+        return tokens.remove(at:0)
+      #endif
     }
-
+    
     return nil
   }
-
+  
   public func prependToken(token:Token) {
     #if !swift(>=3.0)
-    tokens.insert(token, atIndex: 0)
+      tokens.insert(token, atIndex: 0)
     #else
-    tokens.insert(token, at: 0)
+      tokens.insert(token, at: 0)
     #endif
-
-    }
-
+    
+  }
+  
   public func findFilter(name: String) throws -> Filter {
     if let filter = namespace.filters[name] {
       return filter
     }
-
+    
     throw TemplateSyntaxError("Invalid filter '\(name)'")
   }
-
+  
   func compileFilter(token: String) throws -> Resolvable {
     return try FilterExpression(token: token, parser: self)
   }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -67,15 +67,24 @@ public class TokenParser {
 
   public func nextToken() -> Token? {
     if tokens.count > 0 {
+        #if !swift(>=3.0)
       return tokens.removeAtIndex(0)
+        #else
+            return tokens.remove(at:0)
+        #endif
     }
 
     return nil
   }
 
   public func prependToken(token:Token) {
+    #if !swift(>=3.0)
     tokens.insert(token, atIndex: 0)
-  }
+    #else
+    tokens.insert(token, at: 0)
+    #endif
+
+    }
 
   public func findFilter(name: String) throws -> Filter {
     if let filter = namespace.filters[name] {

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -8,41 +8,41 @@ let NSFileNoSuchFileError = 4
 /// A class representing a template
 public class Template {
   let tokens: [Token]
-
+  
   /// Create a template with the given name inside the given bundle
   public convenience init(named:String, inBundle bundle:NSBundle? = nil) throws {
     #if !swift(>=3.0)
-    let useBundle = bundle ??  NSBundle.mainBundle()
-        guard let url = useBundle.URLForResource(named, withExtension: nil) else {
-        throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
-        }
+      let useBundle = bundle ??  NSBundle.mainBundle()
+      guard let url = useBundle.URLForResource(named, withExtension: nil) else {
+      throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
+      }
     #else
-    let useBundle = bundle ??  NSBundle.main()
-        guard let url = useBundle.url(forResource: named, withExtension: nil) else {
-            throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
-        }
+      let useBundle = bundle ??  NSBundle.main()
+      guard let url = useBundle.url(forResource: named, withExtension: nil) else {
+        throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
+      }
     #endif
-
-
+    
+    
     try self.init(URL:url)
   }
-
+  
   /// Create a template with a file found at the given URL
   public convenience init(URL:NSURL) throws {
     try self.init(path: Path(URL.path!))
   }
-
+  
   /// Create a template with a file found at the given path
   public convenience init(path:Path) throws {
     self.init(templateString: try path.read())
   }
-
+  
   /// Create a template with a template string
   public init(templateString:String) {
     let lexer = Lexer(templateString: templateString)
     tokens = lexer.tokenize()
   }
-
+  
   /// Render the given template
   public func render(context: Context? = nil) throws -> String {
     let context = context ?? Context()

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -11,10 +11,18 @@ public class Template {
 
   /// Create a template with the given name inside the given bundle
   public convenience init(named:String, inBundle bundle:NSBundle? = nil) throws {
+    #if !swift(>=3.0)
     let useBundle = bundle ??  NSBundle.mainBundle()
-    guard let url = useBundle.URLForResource(named, withExtension: nil) else {
-      throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
-    }
+        guard let url = useBundle.URLForResource(named, withExtension: nil) else {
+        throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
+        }
+    #else
+    let useBundle = bundle ??  NSBundle.main()
+        guard let url = useBundle.url(forResource: named, withExtension: nil) else {
+            throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
+        }
+    #endif
+
 
     try self.init(URL:url)
   }

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -4,22 +4,22 @@ import Foundation
 class FilterExpression : Resolvable {
   let filters: [Filter]
   let variable: Variable
-
+  
   init(token: String, parser: TokenParser) throws {
     #if !swift(>=3.0)
-    let bits = token.characters.split("|").map({ String($0).trim(" ") })
+      let bits = token.characters.split("|").map({ String($0).trim(" ") })
     #else
-    let bits = token.characters.split(separator:"|").map({ String($0).trim(" ") })
+      let bits = token.characters.split(separator:"|").map({ String($0).trim(" ") })
     #endif
     if bits.isEmpty {
       filters = []
       variable = Variable("")
       throw TemplateSyntaxError("Variable tags must include at least 1 argument")
     }
-
+    
     variable = Variable(bits[0])
     let filterBits = bits[1 ..< bits.endIndex]
-
+    
     do {
       filters = try filterBits.map { try parser.findFilter($0) }
     } catch {
@@ -27,10 +27,10 @@ class FilterExpression : Resolvable {
       throw error
     }
   }
-
+  
   func resolve(context: Context) throws -> Any? {
     let result = try variable.resolve(context)
-
+    
     return try filters.reduce(result) { x, y in
       return try y(x)
     }
@@ -40,32 +40,32 @@ class FilterExpression : Resolvable {
 /// A structure used to represent a template variable, and to resolve it in a given context.
 public struct Variable : Equatable, Resolvable {
   public let variable: String
-
+  
   /// Create a variable with a string representing the variable
   public init(_ variable: String) {
     self.variable = variable
   }
-
+  
   private func lookup() -> [String] {
     #if !swift(>=3.0)
-    return variable.characters.split(".").map(String.init)
+      return variable.characters.split(".").map(String.init)
     #else
-        return variable.characters.split(separator:".").map(String.init)
+      return variable.characters.split(separator:".").map(String.init)
     #endif
-}
-
+  }
+  
   /// Resolve the variable in the given context
   public func resolve(context: Context) throws -> Any? {
     var current: Any? = context
-
+    
     if (variable.hasPrefix("'") && variable.hasSuffix("'")) || (variable.hasPrefix("\"") && variable.hasSuffix("\"")) {
       // String literal
       return variable[variable.startIndex.successor() ..< variable.endIndex.predecessor()]
     }
-
+    
     for bit in lookup() {
       current = normalize(current)
-
+      
       if let context = current as? Context {
         current = context[bit]
       } else if let dictionary = current as? [String: Any] {
@@ -81,20 +81,20 @@ public struct Variable : Equatable, Resolvable {
           current = array.count
         }
       } else if let object = current as? NSObject {  // NSKeyValueCoding
-#if os(Linux)
-        return nil
-#else
-    #if !swift(>=3.0)
-        current = object.valueForKey(bit)
+        #if os(Linux)
+          return nil
         #else
-        current = object.value(forKey:bit)
+          #if !swift(>=3.0)
+            current = object.valueForKey(bit)
+          #else
+            current = object.value(forKey:bit)
+          #endif
         #endif
-#endif
       } else {
         return nil
       }
     }
-
+    
     return normalize(current)
   }
 }
@@ -108,7 +108,7 @@ func normalize(current: Any?) -> Any? {
   if let current = current as? Normalizable {
     return current.normalize()
   }
-
+  
   return current
 }
 
@@ -131,7 +131,7 @@ extension NSArray : Normalizable {
 extension Dictionary : Normalizable {
   func normalize() -> Any? {
     var dictionary: [String: Any] = [:]
-
+    
     for (key, value) in self {
       if let key = key as? String {
         dictionary[key] = Stencil.normalize(value)
@@ -139,7 +139,7 @@ extension Dictionary : Normalizable {
         dictionary[key.description] = Stencil.normalize(value)
       }
     }
-
+    
     return dictionary
   }
 }

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -6,7 +6,11 @@ class FilterExpression : Resolvable {
   let variable: Variable
 
   init(token: String, parser: TokenParser) throws {
+    #if !swift(>=3.0)
     let bits = token.characters.split("|").map({ String($0).trim(" ") })
+    #else
+    let bits = token.characters.split(separator:"|").map({ String($0).trim(" ") })
+    #endif
     if bits.isEmpty {
       filters = []
       variable = Variable("")
@@ -43,8 +47,12 @@ public struct Variable : Equatable, Resolvable {
   }
 
   private func lookup() -> [String] {
+    #if !swift(>=3.0)
     return variable.characters.split(".").map(String.init)
-  }
+    #else
+        return variable.characters.split(separator:".").map(String.init)
+    #endif
+}
 
   /// Resolve the variable in the given context
   public func resolve(context: Context) throws -> Any? {
@@ -76,7 +84,11 @@ public struct Variable : Equatable, Resolvable {
 #if os(Linux)
         return nil
 #else
+    #if !swift(>=3.0)
         current = object.valueForKey(bit)
+        #else
+        current = object.value(forKey:bit)
+        #endif
 #endif
       } else {
         return nil


### PR DESCRIPTION
Hi,

I added support for swift 3.0 (DEVELOPMENT-SNAPSHOT-2016-03-24-a) using macros checking the swift version, so should work both with 2.2 and (current) 3.0 dev.

Changes are mostly about keeping up with the swift-3-api-guidelines induced changes.

I've also updated Package.swift to point to my own updated PathKit release (see PR15 in PathKit), which you likely do not want to merge unless you do not update and release PathKit.

TODO: confirm spectre-build works with swift 3.0 (DEVELOPMENT-SNAPSHOT-2016-03-24-a) and fix where needed, as I didn't touch that at all.