### PR TITLE
Carthage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,33 @@
 .conche/
 .build/
 Packages/
+
+## Xcode generated
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xcuserstate
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Carthage
+Carthage/Checkouts
+Carthage/Build

--- a/Info-iOS.plist
+++ b/Info-iOS.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Info-tvOS.plist
+++ b/Info-tvOS.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Info-watchOS.plist
+++ b/Info-watchOS.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -1,6 +1,3 @@
-import PathKit
-
-
 public class IncludeNode : NodeType {
   public let templateName: Variable
 

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -1,0 +1,711 @@
+// PathKit - Effortless path operations
+
+#if os(Linux)
+import Glibc
+
+let system_glob = Glibc.glob
+#else
+import Darwin
+
+let system_glob = Darwin.glob
+#endif
+
+import Foundation
+
+
+/// Represents a filesystem path.
+public struct Path {
+  /// The character used by the OS to separate two path elements
+  public static let separator = "/"
+
+  /// The underlying string representation
+  internal var path: String
+
+  internal static var fileManager = NSFileManager.defaultManager()
+
+  // MARK: Init
+
+  public init() {
+    self.path = ""
+  }
+
+  /// Create a Path from a given String
+  public init(_ path: String) {
+    self.path = path
+  }
+
+  /// Create a Path by joining multiple path components together
+  public init<S : CollectionType where S.Generator.Element == String>(components: S) {
+    if components.isEmpty {
+      path = "."
+    } else if components.first == Path.separator && components.count > 1 {
+      let p = components.joinWithSeparator(Path.separator)
+#if os(Linux)
+      let index = p.startIndex.distanceTo(p.startIndex.successor())
+      path = NSString(string: p).substringFromIndex(index)
+#else
+      path = p.substringFromIndex(p.startIndex.successor())
+#endif
+
+    } else {
+      path = components.joinWithSeparator(Path.separator)
+    }
+  }
+}
+
+
+// MARK: StringLiteralConvertible
+
+extension Path : StringLiteralConvertible {
+  public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+  public typealias UnicodeScalarLiteralType = StringLiteralType
+
+  public init(extendedGraphemeClusterLiteral path: StringLiteralType) {
+    self.init(stringLiteral: path)
+  }
+
+  public init(unicodeScalarLiteral path: StringLiteralType) {
+    self.init(stringLiteral: path)
+  }
+
+  public init(stringLiteral value: StringLiteralType) {
+    self.path = value
+  }
+}
+
+
+// MARK: CustomStringConvertible
+
+extension Path : CustomStringConvertible {
+  public var description: String {
+    return self.path
+  }
+}
+
+
+// MARK: Hashable
+
+extension Path : Hashable {
+  public var hashValue: Int {
+    return path.hashValue
+  }
+}
+
+
+// MARK: Path Info
+
+extension Path {
+  /// Test whether a path is absolute.
+  ///
+  /// - Returns: `true` iff the path begings with a slash
+  ///
+  public var isAbsolute: Bool {
+    return path.hasPrefix(Path.separator)
+  }
+
+  /// Test whether a path is relative.
+  ///
+  /// - Returns: `true` iff a path is relative (not absolute)
+  ///
+  public var isRelative: Bool {
+    return !isAbsolute
+  }
+
+  /// Concatenates relative paths to the current directory and derives the normalized path
+  ///
+  /// - Returns: the absolute path in the actual filesystem
+  ///
+  public func absolute() -> Path {
+    if isAbsolute {
+      return normalize()
+    }
+
+    return (Path.current + self).normalize()
+  }
+
+  /// Normalizes the path, this cleans up redundant ".." and ".", double slashes
+  /// and resolves "~".
+  ///
+  /// - Returns: a new path made by removing extraneous path components from the underlying String
+  ///   representation.
+  ///
+  public func normalize() -> Path {
+    return Path(NSString(string: self.path).stringByStandardizingPath)
+  }
+
+  /// De-normalizes the path, by replacing the current user home directory with "~".
+  ///
+  /// - Returns: a new path made by removing extraneous path components from the underlying String
+  ///   representation.
+  ///
+  public func abbreviate() -> Path {
+#if os(Linux)
+    // TODO: actually de-normalize the path
+    return self
+#else
+    return Path(NSString(string: self.path).stringByAbbreviatingWithTildeInPath)
+#endif
+  }
+
+  /// Returns the path of the item pointed to by a symbolic link.
+  ///
+  /// - Returns: the path of directory or file to which the symbolic link refers
+  ///
+  public func symlinkDestination() throws -> Path {
+    let symlinkDestination = try Path.fileManager.destinationOfSymbolicLinkAtPath(path)
+    let symlinkPath = Path(symlinkDestination)
+    if symlinkPath.isRelative {
+      return self + ".." + symlinkPath
+    } else {
+      return symlinkPath
+    }
+  }
+}
+
+
+// MARK: Path Components
+
+extension Path {
+  /// The last path component
+  ///
+  /// - Returns: the last path component
+  ///
+  public var lastComponent: String {
+    return NSString(string: path).lastPathComponent
+  }
+
+  /// The last path component without file extension
+  ///
+  /// - Note: This returns "." for "..".
+  ///
+  /// - Returns: the last path component without file extension
+  ///
+  public var lastComponentWithoutExtension: String {
+    return NSString(string: lastComponent).stringByDeletingPathExtension
+  }
+
+  /// Splits the string representation on the directory separator.
+  /// Absolute paths remain the leading slash as first component.
+  ///
+  /// - Returns: all path components
+  ///
+  public var components: [String] {
+    return NSString(string: path).pathComponents
+  }
+
+  /// The file extension behind the last dot of the last component.
+  ///
+  /// - Returns: the file extension
+  ///
+  public var `extension`: String? {
+    let pathExtension = NSString(string: path).pathExtension
+    if  pathExtension.isEmpty {
+      return nil
+    }
+
+    return pathExtension
+  }
+}
+
+
+// MARK: File Info
+
+extension Path {
+  /// Test whether a file or directory exists at a specified path
+  ///
+  /// - Returns: `false` iff the path doesn't exist on disk or its existence could not be
+  ///   determined
+  ///
+  public var exists: Bool {
+    return Path.fileManager.fileExistsAtPath(self.path)
+  }
+
+  /// Test whether a path is a directory.
+  ///
+  /// - Returns: `true` if the path is a directory or a symbolic link that points to a directory;
+  ///   `false` if the path is not a directory or the path doesn't exist on disk or its existence
+  ///   could not be determined
+  ///
+  public var isDirectory: Bool {
+    var directory = ObjCBool(false)
+    guard Path.fileManager.fileExistsAtPath(normalize().path, isDirectory: &directory) else {
+      return false
+    }
+    return directory.boolValue
+  }
+
+  /// Test whether a path is a regular file.
+  ///
+  /// - Returns: `true` if the path is neither a directory nor a symbolic link that points to a
+  ///   directory; `false` if the path is a directory or a symbolic link that points to a
+  ///   directory or the path doesn't exist on disk or its existence
+  ///   could not be determined
+  ///
+  public var isFile: Bool {
+    var directory = ObjCBool(false)
+    guard Path.fileManager.fileExistsAtPath(normalize().path, isDirectory: &directory) else {
+      return false
+    }
+    return !directory.boolValue
+  }
+
+  /// Test whether a path is a symbolic link.
+  ///
+  /// - Returns: `true` if the path is a symbolic link; `false` if the path doesn't exist on disk
+  ///   or its existence could not be determined
+  ///
+  public var isSymlink: Bool {
+    do {
+      let _ = try Path.fileManager.destinationOfSymbolicLinkAtPath(path)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /// Test whether a path is readable
+  ///
+  /// - Returns: `true` if the current process has read privileges for the file at path;
+  ///   otherwise `false` if the process does not have read privileges or the existence of the
+  ///   file could not be determined.
+  ///
+  public var isReadable: Bool {
+    return Path.fileManager.isReadableFileAtPath(self.path)
+  }
+
+  /// Test whether a path is writeable
+  ///
+  /// - Returns: `true` if the current process has write privileges for the file at path;
+  ///   otherwise `false` if the process does not have write privileges or the existence of the
+  ///   file could not be determined.
+  ///
+  public var isWritable: Bool {
+    return Path.fileManager.isWritableFileAtPath(self.path)
+  }
+
+  /// Test whether a path is executable
+  ///
+  /// - Returns: `true` if the current process has execute privileges for the file at path;
+  ///   otherwise `false` if the process does not have execute privileges or the existence of the
+  ///   file could not be determined.
+  ///
+  public var isExecutable: Bool {
+    return Path.fileManager.isExecutableFileAtPath(self.path)
+  }
+
+  /// Test whether a path is deletable
+  ///
+  /// - Returns: `true` if the current process has delete privileges for the file at path;
+  ///   otherwise `false` if the process does not have delete privileges or the existence of the
+  ///   file could not be determined.
+  ///
+  public var isDeletable: Bool {
+    return Path.fileManager.isDeletableFileAtPath(self.path)
+  }
+}
+
+
+// MARK: File Manipulation
+
+extension Path {
+  /// Create the directory.
+  ///
+  /// - Note: This method fails if any of the intermediate parent directories does not exist.
+  ///   This method also fails if any of the intermediate path elements corresponds to a file and
+  ///   not a directory.
+  ///
+  public func mkdir() throws -> () {
+    try Path.fileManager.createDirectoryAtPath(self.path, withIntermediateDirectories: false, attributes: nil)
+  }
+
+  /// Create the directory and any intermediate parent directories that do not exist.
+  ///
+  /// - Note: This method fails if any of the intermediate path elements corresponds to a file and
+  ///   not a directory.
+  ///
+  public func mkpath() throws -> () {
+    try Path.fileManager.createDirectoryAtPath(self.path, withIntermediateDirectories: true, attributes: nil)
+  }
+
+  /// Delete the file or directory.
+  ///
+  /// - Note: If the path specifies a directory, the contents of that directory are recursively
+  ///   removed.
+  ///
+  public func delete() throws -> () {
+    try Path.fileManager.removeItemAtPath(self.path)
+  }
+
+  /// Move the file or directory to a new location synchronously.
+  ///
+  /// - Parameter destination: The new path. This path must include the name of the file or
+  ///   directory in its new location.
+  ///
+  public func move(destination: Path) throws -> () {
+    try Path.fileManager.moveItemAtPath(self.path, toPath: destination.path)
+  }
+
+  /// Copy the file or directory to a new location synchronously.
+  ///
+  /// - Parameter destination: The new path. This path must include the name of the file or
+  ///   directory in its new location.
+  ///
+  public func copy(destination: Path) throws -> () {
+    try Path.fileManager.copyItemAtPath(self.path, toPath: destination.path)
+  }
+
+  /// Creates a hard link at a new destination.
+  ///
+  /// - Parameter destination: The location where the link will be created.
+  ///
+  public func link(destination: Path) throws -> () {
+    try Path.fileManager.linkItemAtPath(self.path, toPath: destination.path)
+  }
+
+  /// Creates a symbolic link at a new destination.
+  ///
+  /// - Parameter destintation: The location where the link will be created.
+  ///
+  public func symlink(destination: Path) throws -> () {
+    try Path.fileManager.createSymbolicLinkAtPath(self.path, withDestinationPath: destination.path)
+  }
+}
+
+
+// MARK: Current Directory
+
+extension Path {
+  /// The current working directory of the process
+  ///
+  /// - Returns: the current working directory of the process
+  ///
+  public static var current: Path {
+    get {
+      return self.init(Path.fileManager.currentDirectoryPath)
+    }
+    set {
+      Path.fileManager.changeCurrentDirectoryPath(newValue.description)
+    }
+  }
+
+  /// Changes the current working directory of the process to the path during the execution of the
+  /// given block.
+  ///
+  /// - Note: The original working directory is restored when the block returns or throws.
+  /// - Parameter closure: A closure to be executed while the current directory is configured to
+  ///   the path.
+  ///
+  public func chdir(@noescape closure: () throws -> ()) rethrows {
+    let previous = Path.current
+    Path.current = self
+    defer { Path.current = previous }
+    try closure()
+    }
+}
+
+
+// MARK: Temporary
+
+extension Path {
+  /// - Returns: the path to either the user’s or application’s home directory,
+  ///   depending on the platform.
+  ///
+  public static var home: Path {
+#if os(Linux)
+    return Path(NSProcessInfo.processInfo().environment["HOME"] ?? "/")
+#else
+    return Path(NSHomeDirectory())
+#endif
+  }
+
+  /// - Returns: the path of the temporary directory for the current user.
+  ///
+  public static var temporary: Path {
+#if os(Linux)
+    return Path(NSProcessInfo.processInfo().environment["TMP"] ?? "/tmp")
+#else
+    return Path(NSTemporaryDirectory())
+#endif
+  }
+
+  /// - Returns: the path of a temporary directory unique for the process.
+  /// - Note: Based on `NSProcessInfo.globallyUniqueString`.
+  ///
+  public static func processUniqueTemporary() throws -> Path {
+    let path = temporary + NSProcessInfo.processInfo().globallyUniqueString
+    if !path.exists {
+      try path.mkdir()
+    }
+    return path
+  }
+
+  /// - Returns: the path of a temporary directory unique for each call.
+  /// - Note: Based on `NSUUID`.
+  ///
+  public static func uniqueTemporary() throws -> Path {
+    let path = try processUniqueTemporary() + NSUUID().UUIDString
+    try path.mkdir()
+    return path
+  }
+}
+
+
+// MARK: Contents
+
+extension Path {
+  /// Reads the file.
+  ///
+  /// - Returns: the contents of the file at the specified path.
+  ///
+  public func read() throws -> NSData {
+    return try NSData(contentsOfFile: path, options: NSDataReadingOptions(rawValue: 0))
+  }
+
+  /// Reads the file contents and encoded its bytes to string applying the given encoding.
+  ///
+  /// - Parameter encoding: the encoding which should be used to decode the data.
+  ///   (by default: `NSUTF8StringEncoding`)
+  ///
+  /// - Returns: the contents of the file at the specified path as string.
+  ///
+  public func read(encoding: NSStringEncoding = NSUTF8StringEncoding) throws -> String {
+    return try NSString(contentsOfFile: path, encoding: encoding).substringFromIndex(0) as String
+  }
+
+  /// Write a file.
+  ///
+  /// - Note: Works atomically: the data is written to a backup file, and then — assuming no
+  ///   errors occur — the backup file is renamed to the name specified by path.
+  ///
+  /// - Parameter data: the contents to write to file.
+  ///
+  public func write(data: NSData) throws {
+    try data.writeToFile(normalize().path, options: .DataWritingAtomic)
+  }
+
+  /// Reads the file.
+  ///
+  /// - Note: Works atomically: the data is written to a backup file, and then — assuming no
+  ///   errors occur — the backup file is renamed to the name specified by path.
+  ///
+  /// - Parameter string: the string to write to file.
+  ///
+  /// - Parameter encoding: the encoding which should be used to represent the string as bytes.
+  ///   (by default: `NSUTF8StringEncoding`)
+  ///
+  /// - Returns: the contents of the file at the specified path as string.
+  ///
+  public func write(string: String, encoding: NSStringEncoding = NSUTF8StringEncoding) throws {
+    try NSString(string: string).writeToFile(normalize().path, atomically: true, encoding: encoding)
+  }
+}
+
+
+// MARK: Traversing
+
+extension Path {
+  /// Get the parent directory
+  ///
+  /// - Returns: the normalized path of the parent directory
+  ///
+  public func parent() -> Path {
+    return self + ".."
+  }
+
+  /// Performs a shallow enumeration in a directory
+  ///
+  /// - Returns: paths to all files, directories and symbolic links contained in the directory
+  ///
+  public func children() throws -> [Path] {
+    return try Path.fileManager.contentsOfDirectoryAtPath(path).map {
+      self + Path($0)
+    }
+  }
+
+  /// Performs a deep enumeration in a directory
+  ///
+  /// - Returns: paths to all files, directories and symbolic links contained in the directory or
+  ///   any subdirectory.
+  ///
+  public func recursiveChildren() throws -> [Path] {
+    return try Path.fileManager.subpathsOfDirectoryAtPath(path).map {
+      self + Path($0)
+    }
+  }
+}
+
+
+// MARK: Globbing
+
+extension Path {
+  public static func glob(pattern: String) -> [Path] {
+    var gt = glob_t()
+    let cPattern = strdup(pattern)
+    defer {
+      globfree(&gt)
+      free(cPattern)
+    }
+
+    let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
+    if system_glob(cPattern, flags, nil, &gt) == 0 {
+#if os(Linux)
+      let matchc = gt.gl_pathc
+#else
+      let matchc = gt.gl_matchc
+#endif
+      return (0..<Int(matchc)).flatMap { index in
+        if let path = String.fromCString(gt.gl_pathv[index]) {
+          return Path(path)
+        }
+
+        return nil
+      }
+    }
+
+    // GLOB_NOMATCH
+    return []
+  }
+
+  public func glob(pattern: String) -> [Path] {
+    return Path.glob((self + pattern).description)
+  }
+}
+
+
+// MARK: SequenceType
+
+extension Path : SequenceType {
+  /// Enumerates the contents of a directory, returning the paths of all files and directories
+  /// contained within that directory. These paths are relative to the directory.
+  public struct DirectoryEnumerator : GeneratorType {
+    public typealias Element = Path
+
+    let path: Path
+    let directoryEnumerator: NSDirectoryEnumerator
+
+    init(path: Path) {
+      self.path = path
+      self.directoryEnumerator = Path.fileManager.enumeratorAtPath(path.path)!
+    }
+
+    public func next() -> Path? {
+      if let next = directoryEnumerator.nextObject() as! String? {
+        return path + next
+      }
+      return nil
+    }
+
+    /// Skip recursion into the most recently obtained subdirectory.
+    public func skipDescendants() {
+      directoryEnumerator.skipDescendants()
+    }
+  }
+
+  /// Perform a deep enumeration of a directory.
+  ///
+  /// - Returns: a directory enumerator that can be used to perform a deep enumeration of the
+  ///   directory.
+  ///
+  public func generate() -> DirectoryEnumerator {
+    return DirectoryEnumerator(path: self)
+  }
+}
+
+
+// MARK: Equatable
+
+extension Path : Equatable {}
+
+/// Determines if two paths are identical
+///
+/// - Note: The comparison is string-based. Be aware that two different paths (foo.txt and
+///   ./foo.txt) can refer to the same file.
+///
+public func ==(lhs: Path, rhs: Path) -> Bool {
+  return lhs.path == rhs.path
+}
+
+
+// MARK: Pattern Matching
+
+/// Implements pattern-matching for paths.
+///
+/// - Returns: `true` iff one of the following conditions is true:
+///     - the paths are equal (based on `Path`'s `Equatable` implementation)
+///     - the paths can be normalized to equal Paths.
+///
+public func ~=(lhs: Path, rhs: Path) -> Bool {
+  return lhs == rhs
+    || lhs.normalize() == rhs.normalize()
+}
+
+
+// MARK: Comparable
+
+extension Path : Comparable {}
+
+/// Defines a strict total order over Paths based on their underlying string representation.
+public func <(lhs: Path, rhs: Path) -> Bool {
+  return lhs.path < rhs.path
+}
+
+
+// MARK: Operators
+
+/// Appends a Path fragment to another Path to produce a new Path
+public func +(lhs: Path, rhs: Path) -> Path {
+  return lhs.path + rhs.path
+}
+
+/// Appends a String fragment to another Path to produce a new Path
+public func +(lhs: Path, rhs: String) -> Path {
+  return lhs.path + rhs
+}
+
+/// Appends a String fragment to another String to produce a new Path
+internal func +(lhs: String, rhs: String) -> Path {
+  if rhs.hasPrefix(Path.separator) {
+    // Absolute paths replace relative paths
+    return Path(rhs)
+  } else {
+    var lSlice = NSString(string: lhs).pathComponents.fullSlice
+    var rSlice = NSString(string: rhs).pathComponents.fullSlice
+
+    // Get rid of trailing "/" at the left side
+    if lSlice.count > 1 && lSlice.last == Path.separator {
+      lSlice.removeLast()
+    }
+
+    // Advance after the first relevant "."
+    lSlice = lSlice.filter { $0 != "." }.fullSlice
+    rSlice = rSlice.filter { $0 != "." }.fullSlice
+
+    // Eats up trailing components of the left and leading ".." of the right side
+    while lSlice.last != ".." && rSlice.first == ".." {
+      if (lSlice.count > 1 || lSlice.first != Path.separator) && !lSlice.isEmpty {
+        // A leading "/" is never popped
+        lSlice.removeLast()
+      }
+      if !rSlice.isEmpty {
+        rSlice.removeFirst()
+      }
+
+      switch (lSlice.isEmpty, rSlice.isEmpty) {
+      case (true, _):
+        break
+      case (_, true):
+        break
+      default:
+        continue
+      }
+    }
+
+    return Path(components: lSlice + rSlice)
+  }
+}
+
+extension Array {
+  var fullSlice: ArraySlice<Element> {
+    return self[0..<self.endIndex]
+  }
+}

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PathKit
 
 #if os(Linux)
 let NSFileNoSuchFileError = 4

--- a/Sources/TemplateLoader.swift
+++ b/Sources/TemplateLoader.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PathKit
 
 
 // A class for loading a template from disk

--- a/Stencil.h
+++ b/Stencil.h
@@ -1,0 +1,17 @@
+//
+//  Stencil.h
+//  Stencil
+//
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Stencil.
+FOUNDATION_EXPORT double StencilVersionNumber;
+
+//! Project version string for Stencil.
+FOUNDATION_EXPORT const unsigned char StencilVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Stencil/PublicHeader.h>
+
+

--- a/Stencil.xcodeproj/project.pbxproj
+++ b/Stencil.xcodeproj/project.pbxproj
@@ -1,0 +1,732 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		8B6D087A1CD7F9F500E91826 /* Stencil.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6D08791CD7F9F500E91826 /* Stencil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B6D088F1CD7F9FF00E91826 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08801CD7F9FF00E91826 /* Context.swift */; };
+		8B6D08901CD7F9FF00E91826 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08811CD7F9FF00E91826 /* Filters.swift */; };
+		8B6D08911CD7F9FF00E91826 /* ForTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08821CD7F9FF00E91826 /* ForTag.swift */; };
+		8B6D08921CD7F9FF00E91826 /* IfTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08831CD7F9FF00E91826 /* IfTag.swift */; };
+		8B6D08931CD7F9FF00E91826 /* Include.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08841CD7F9FF00E91826 /* Include.swift */; };
+		8B6D08941CD7F9FF00E91826 /* Inheritence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08851CD7F9FF00E91826 /* Inheritence.swift */; };
+		8B6D08951CD7F9FF00E91826 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08861CD7F9FF00E91826 /* Lexer.swift */; };
+		8B6D08961CD7F9FF00E91826 /* Namespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08871CD7F9FF00E91826 /* Namespace.swift */; };
+		8B6D08971CD7F9FF00E91826 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08881CD7F9FF00E91826 /* Node.swift */; };
+		8B6D08981CD7F9FF00E91826 /* NowTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08891CD7F9FF00E91826 /* NowTag.swift */; };
+		8B6D08991CD7F9FF00E91826 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088A1CD7F9FF00E91826 /* Parser.swift */; };
+		8B6D089A1CD7F9FF00E91826 /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088B1CD7F9FF00E91826 /* Template.swift */; };
+		8B6D089B1CD7F9FF00E91826 /* TemplateLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088C1CD7F9FF00E91826 /* TemplateLoader.swift */; };
+		8B6D089C1CD7F9FF00E91826 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088D1CD7F9FF00E91826 /* Tokenizer.swift */; };
+		8B6D089D1CD7F9FF00E91826 /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088E1CD7F9FF00E91826 /* Variable.swift */; };
+		8B6D08D91CD7FC9C00E91826 /* Stencil.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6D08791CD7F9F500E91826 /* Stencil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B6D08DA1CD7FC9D00E91826 /* Stencil.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6D08791CD7F9F500E91826 /* Stencil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B6D08DC1CD7FDFD00E91826 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08DB1CD7FDFD00E91826 /* PathKit.swift */; };
+		8B6D08DD1CD7FDFD00E91826 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08DB1CD7FDFD00E91826 /* PathKit.swift */; };
+		8B6D08DE1CD7FDFD00E91826 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08DB1CD7FDFD00E91826 /* PathKit.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		8B6D08761CD7F9F500E91826 /* Stencil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B6D08791CD7F9F500E91826 /* Stencil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stencil.h; sourceTree = "<group>"; };
+		8B6D08801CD7F9FF00E91826 /* Context.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
+		8B6D08811CD7F9FF00E91826 /* Filters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
+		8B6D08821CD7F9FF00E91826 /* ForTag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForTag.swift; sourceTree = "<group>"; };
+		8B6D08831CD7F9FF00E91826 /* IfTag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IfTag.swift; sourceTree = "<group>"; };
+		8B6D08841CD7F9FF00E91826 /* Include.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Include.swift; sourceTree = "<group>"; };
+		8B6D08851CD7F9FF00E91826 /* Inheritence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Inheritence.swift; sourceTree = "<group>"; };
+		8B6D08861CD7F9FF00E91826 /* Lexer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lexer.swift; sourceTree = "<group>"; };
+		8B6D08871CD7F9FF00E91826 /* Namespace.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Namespace.swift; sourceTree = "<group>"; };
+		8B6D08881CD7F9FF00E91826 /* Node.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		8B6D08891CD7F9FF00E91826 /* NowTag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NowTag.swift; sourceTree = "<group>"; };
+		8B6D088A1CD7F9FF00E91826 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		8B6D088B1CD7F9FF00E91826 /* Template.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Template.swift; sourceTree = "<group>"; };
+		8B6D088C1CD7F9FF00E91826 /* TemplateLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TemplateLoader.swift; sourceTree = "<group>"; };
+		8B6D088D1CD7F9FF00E91826 /* Tokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
+		8B6D088E1CD7F9FF00E91826 /* Variable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Variable.swift; sourceTree = "<group>"; };
+		8B6D08A31CD7FA2800E91826 /* Stencil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B6D08BD1CD7FA4300E91826 /* Stencil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B6D08C61CD7FAEA00E91826 /* ARCHITECTURE.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = ARCHITECTURE.md; sourceTree = "<group>"; };
+		8B6D08C71CD7FAEA00E91826 /* Info-iOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
+		8B6D08C81CD7FAEA00E91826 /* Info-tvOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		8B6D08C91CD7FAEA00E91826 /* Info-watchOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-watchOS.plist"; sourceTree = "<group>"; };
+		8B6D08CA1CD7FAEA00E91826 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		8B6D08CB1CD7FAEA00E91826 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		8B6D08CC1CD7FAEA00E91826 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		8B6D08CD1CD7FAEA00E91826 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		8B6D08CE1CD7FAEA00E91826 /* Stencil.podspec.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Stencil.podspec.json; sourceTree = "<group>"; };
+		8B6D08DB1CD7FDFD00E91826 /* PathKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathKit.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8B6D08721CD7F9F500E91826 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B6D089F1CD7FA2800E91826 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B6D08B91CD7FA4300E91826 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		8B6D086A1CD7F96400E91826 = {
+			isa = PBXGroup;
+			children = (
+				8B6D08C51CD7FA6800E91826 /* Metadata */,
+				8B6D087F1CD7F9FF00E91826 /* Sources */,
+				8B6D08D81CD7FC3D00E91826 /* Supporting Files */,
+				8B6D08771CD7F9F500E91826 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		8B6D08771CD7F9F500E91826 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8B6D08761CD7F9F500E91826 /* Stencil.framework */,
+				8B6D08A31CD7FA2800E91826 /* Stencil.framework */,
+				8B6D08BD1CD7FA4300E91826 /* Stencil.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8B6D087F1CD7F9FF00E91826 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				8B6D08801CD7F9FF00E91826 /* Context.swift */,
+				8B6D08811CD7F9FF00E91826 /* Filters.swift */,
+				8B6D08821CD7F9FF00E91826 /* ForTag.swift */,
+				8B6D08831CD7F9FF00E91826 /* IfTag.swift */,
+				8B6D08841CD7F9FF00E91826 /* Include.swift */,
+				8B6D08851CD7F9FF00E91826 /* Inheritence.swift */,
+				8B6D08861CD7F9FF00E91826 /* Lexer.swift */,
+				8B6D08871CD7F9FF00E91826 /* Namespace.swift */,
+				8B6D08881CD7F9FF00E91826 /* Node.swift */,
+				8B6D08891CD7F9FF00E91826 /* NowTag.swift */,
+				8B6D088A1CD7F9FF00E91826 /* Parser.swift */,
+				8B6D08DB1CD7FDFD00E91826 /* PathKit.swift */,
+				8B6D088B1CD7F9FF00E91826 /* Template.swift */,
+				8B6D088C1CD7F9FF00E91826 /* TemplateLoader.swift */,
+				8B6D088D1CD7F9FF00E91826 /* Tokenizer.swift */,
+				8B6D088E1CD7F9FF00E91826 /* Variable.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		8B6D08C51CD7FA6800E91826 /* Metadata */ = {
+			isa = PBXGroup;
+			children = (
+				8B6D08C61CD7FAEA00E91826 /* ARCHITECTURE.md */,
+				8B6D08CA1CD7FAEA00E91826 /* LICENSE */,
+				8B6D08CB1CD7FAEA00E91826 /* Makefile */,
+				8B6D08CD1CD7FAEA00E91826 /* README.md */,
+				8B6D08CE1CD7FAEA00E91826 /* Stencil.podspec.json */,
+			);
+			name = Metadata;
+			sourceTree = "<group>";
+		};
+		8B6D08D81CD7FC3D00E91826 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				8B6D08C71CD7FAEA00E91826 /* Info-iOS.plist */,
+				8B6D08C81CD7FAEA00E91826 /* Info-tvOS.plist */,
+				8B6D08C91CD7FAEA00E91826 /* Info-watchOS.plist */,
+				8B6D08CC1CD7FAEA00E91826 /* Package.swift */,
+				8B6D08791CD7F9F500E91826 /* Stencil.h */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		8B6D08731CD7F9F500E91826 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B6D087A1CD7F9F500E91826 /* Stencil.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B6D08A01CD7FA2800E91826 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B6D08D91CD7FC9C00E91826 /* Stencil.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B6D08BA1CD7FA4300E91826 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B6D08DA1CD7FC9D00E91826 /* Stencil.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		8B6D08751CD7F9F500E91826 /* Stencil iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8B6D087E1CD7F9F500E91826 /* Build configuration list for PBXNativeTarget "Stencil iOS" */;
+			buildPhases = (
+				8B6D08711CD7F9F500E91826 /* Sources */,
+				8B6D08721CD7F9F500E91826 /* Frameworks */,
+				8B6D08731CD7F9F500E91826 /* Headers */,
+				8B6D08741CD7F9F500E91826 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stencil iOS";
+			productName = "Stencil iOS";
+			productReference = 8B6D08761CD7F9F500E91826 /* Stencil.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8B6D08A21CD7FA2800E91826 /* Stencil watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8B6D08A81CD7FA2800E91826 /* Build configuration list for PBXNativeTarget "Stencil watchOS" */;
+			buildPhases = (
+				8B6D089E1CD7FA2800E91826 /* Sources */,
+				8B6D089F1CD7FA2800E91826 /* Frameworks */,
+				8B6D08A01CD7FA2800E91826 /* Headers */,
+				8B6D08A11CD7FA2800E91826 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stencil watchOS";
+			productName = "Stencil watchOS";
+			productReference = 8B6D08A31CD7FA2800E91826 /* Stencil.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8B6D08BC1CD7FA4300E91826 /* Stencil tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8B6D08C21CD7FA4300E91826 /* Build configuration list for PBXNativeTarget "Stencil tvOS" */;
+			buildPhases = (
+				8B6D08B81CD7FA4300E91826 /* Sources */,
+				8B6D08B91CD7FA4300E91826 /* Frameworks */,
+				8B6D08BA1CD7FA4300E91826 /* Headers */,
+				8B6D08BB1CD7FA4300E91826 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stencil tvOS";
+			productName = "Stencil tvOS";
+			productReference = 8B6D08BD1CD7FA4300E91826 /* Stencil.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		8B6D086B1CD7F96400E91826 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				TargetAttributes = {
+					8B6D08751CD7F9F500E91826 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					8B6D08A21CD7FA2800E91826 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					8B6D08BC1CD7FA4300E91826 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
+			};
+			buildConfigurationList = 8B6D086E1CD7F96400E91826 /* Build configuration list for PBXProject "Stencil" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 8B6D086A1CD7F96400E91826;
+			productRefGroup = 8B6D08771CD7F9F500E91826 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8B6D08751CD7F9F500E91826 /* Stencil iOS */,
+				8B6D08A21CD7FA2800E91826 /* Stencil watchOS */,
+				8B6D08BC1CD7FA4300E91826 /* Stencil tvOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8B6D08741CD7F9F500E91826 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B6D08A11CD7FA2800E91826 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B6D08BB1CD7FA4300E91826 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8B6D08711CD7F9F500E91826 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B6D08941CD7F9FF00E91826 /* Inheritence.swift in Sources */,
+				8B6D08991CD7F9FF00E91826 /* Parser.swift in Sources */,
+				8B6D08981CD7F9FF00E91826 /* NowTag.swift in Sources */,
+				8B6D089C1CD7F9FF00E91826 /* Tokenizer.swift in Sources */,
+				8B6D089D1CD7F9FF00E91826 /* Variable.swift in Sources */,
+				8B6D08951CD7F9FF00E91826 /* Lexer.swift in Sources */,
+				8B6D08931CD7F9FF00E91826 /* Include.swift in Sources */,
+				8B6D08971CD7F9FF00E91826 /* Node.swift in Sources */,
+				8B6D088F1CD7F9FF00E91826 /* Context.swift in Sources */,
+				8B6D08921CD7F9FF00E91826 /* IfTag.swift in Sources */,
+				8B6D08DC1CD7FDFD00E91826 /* PathKit.swift in Sources */,
+				8B6D08911CD7F9FF00E91826 /* ForTag.swift in Sources */,
+				8B6D089B1CD7F9FF00E91826 /* TemplateLoader.swift in Sources */,
+				8B6D089A1CD7F9FF00E91826 /* Template.swift in Sources */,
+				8B6D08901CD7F9FF00E91826 /* Filters.swift in Sources */,
+				8B6D08961CD7F9FF00E91826 /* Namespace.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B6D089E1CD7FA2800E91826 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B6D08DD1CD7FDFD00E91826 /* PathKit.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B6D08B81CD7FA4300E91826 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B6D08DE1CD7FDFD00E91826 /* PathKit.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		8B6D086F1CD7F96400E91826 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+			};
+			name = Debug;
+		};
+		8B6D08701CD7F96400E91826 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+			};
+			name = Release;
+		};
+		8B6D087C1CD7F9F500E91826 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Info-iOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.Stencil-iOS";
+				PRODUCT_NAME = Stencil;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8B6D087D1CD7F9F500E91826 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Info-iOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.Stencil-iOS";
+				PRODUCT_NAME = Stencil;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		8B6D08A91CD7FA2800E91826 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Info-watchOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.Stencil-watchOS";
+				PRODUCT_NAME = Stencil;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		8B6D08AA1CD7FA2800E91826 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Info-watchOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.Stencil-watchOS";
+				PRODUCT_NAME = Stencil;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		8B6D08C31CD7FA4300E91826 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Info-tvOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.Stencil-tvOS";
+				PRODUCT_NAME = Stencil;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8B6D08C41CD7FA4300E91826 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "Info-tvOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocode.Stencil-tvOS";
+				PRODUCT_NAME = Stencil;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8B6D086E1CD7F96400E91826 /* Build configuration list for PBXProject "Stencil" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8B6D086F1CD7F96400E91826 /* Debug */,
+				8B6D08701CD7F96400E91826 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8B6D087E1CD7F9F500E91826 /* Build configuration list for PBXNativeTarget "Stencil iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8B6D087C1CD7F9F500E91826 /* Debug */,
+				8B6D087D1CD7F9F500E91826 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		8B6D08A81CD7FA2800E91826 /* Build configuration list for PBXNativeTarget "Stencil watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8B6D08A91CD7FA2800E91826 /* Debug */,
+				8B6D08AA1CD7FA2800E91826 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		8B6D08C21CD7FA4300E91826 /* Build configuration list for PBXNativeTarget "Stencil tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8B6D08C31CD7FA4300E91826 /* Debug */,
+				8B6D08C41CD7FA4300E91826 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 8B6D086B1CD7F96400E91826 /* Project object */;
+}

--- a/Stencil.xcodeproj/project.pbxproj
+++ b/Stencil.xcodeproj/project.pbxproj
@@ -7,6 +7,36 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8B411F0A1CD8396E00623CAD /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08801CD7F9FF00E91826 /* Context.swift */; };
+		8B411F0B1CD8396E00623CAD /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08811CD7F9FF00E91826 /* Filters.swift */; };
+		8B411F0C1CD8396E00623CAD /* ForTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08821CD7F9FF00E91826 /* ForTag.swift */; };
+		8B411F0D1CD8396E00623CAD /* IfTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08831CD7F9FF00E91826 /* IfTag.swift */; };
+		8B411F0E1CD8396E00623CAD /* Include.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08841CD7F9FF00E91826 /* Include.swift */; };
+		8B411F0F1CD8396E00623CAD /* Inheritence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08851CD7F9FF00E91826 /* Inheritence.swift */; };
+		8B411F101CD8396E00623CAD /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08861CD7F9FF00E91826 /* Lexer.swift */; };
+		8B411F111CD8396E00623CAD /* Namespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08871CD7F9FF00E91826 /* Namespace.swift */; };
+		8B411F121CD8396E00623CAD /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08881CD7F9FF00E91826 /* Node.swift */; };
+		8B411F131CD8396E00623CAD /* NowTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08891CD7F9FF00E91826 /* NowTag.swift */; };
+		8B411F141CD8396E00623CAD /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088A1CD7F9FF00E91826 /* Parser.swift */; };
+		8B411F151CD8396E00623CAD /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088B1CD7F9FF00E91826 /* Template.swift */; };
+		8B411F161CD8396E00623CAD /* TemplateLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088C1CD7F9FF00E91826 /* TemplateLoader.swift */; };
+		8B411F171CD8396E00623CAD /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088D1CD7F9FF00E91826 /* Tokenizer.swift */; };
+		8B411F181CD8396E00623CAD /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088E1CD7F9FF00E91826 /* Variable.swift */; };
+		8B411F191CD8396F00623CAD /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08801CD7F9FF00E91826 /* Context.swift */; };
+		8B411F1A1CD8396F00623CAD /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08811CD7F9FF00E91826 /* Filters.swift */; };
+		8B411F1B1CD8396F00623CAD /* ForTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08821CD7F9FF00E91826 /* ForTag.swift */; };
+		8B411F1C1CD8396F00623CAD /* IfTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08831CD7F9FF00E91826 /* IfTag.swift */; };
+		8B411F1D1CD8396F00623CAD /* Include.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08841CD7F9FF00E91826 /* Include.swift */; };
+		8B411F1E1CD8396F00623CAD /* Inheritence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08851CD7F9FF00E91826 /* Inheritence.swift */; };
+		8B411F1F1CD8396F00623CAD /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08861CD7F9FF00E91826 /* Lexer.swift */; };
+		8B411F201CD8396F00623CAD /* Namespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08871CD7F9FF00E91826 /* Namespace.swift */; };
+		8B411F211CD8396F00623CAD /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08881CD7F9FF00E91826 /* Node.swift */; };
+		8B411F221CD8396F00623CAD /* NowTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08891CD7F9FF00E91826 /* NowTag.swift */; };
+		8B411F231CD8396F00623CAD /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088A1CD7F9FF00E91826 /* Parser.swift */; };
+		8B411F241CD8396F00623CAD /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088B1CD7F9FF00E91826 /* Template.swift */; };
+		8B411F251CD8396F00623CAD /* TemplateLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088C1CD7F9FF00E91826 /* TemplateLoader.swift */; };
+		8B411F261CD8396F00623CAD /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088D1CD7F9FF00E91826 /* Tokenizer.swift */; };
+		8B411F271CD8396F00623CAD /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D088E1CD7F9FF00E91826 /* Variable.swift */; };
 		8B6D087A1CD7F9F500E91826 /* Stencil.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6D08791CD7F9F500E91826 /* Stencil.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B6D088F1CD7F9FF00E91826 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08801CD7F9FF00E91826 /* Context.swift */; };
 		8B6D08901CD7F9FF00E91826 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6D08811CD7F9FF00E91826 /* Filters.swift */; };
@@ -328,7 +358,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B411F0B1CD8396E00623CAD /* Filters.swift in Sources */,
+				8B411F171CD8396E00623CAD /* Tokenizer.swift in Sources */,
+				8B411F121CD8396E00623CAD /* Node.swift in Sources */,
+				8B411F151CD8396E00623CAD /* Template.swift in Sources */,
+				8B411F111CD8396E00623CAD /* Namespace.swift in Sources */,
 				8B6D08DD1CD7FDFD00E91826 /* PathKit.swift in Sources */,
+				8B411F0E1CD8396E00623CAD /* Include.swift in Sources */,
+				8B411F131CD8396E00623CAD /* NowTag.swift in Sources */,
+				8B411F0D1CD8396E00623CAD /* IfTag.swift in Sources */,
+				8B411F161CD8396E00623CAD /* TemplateLoader.swift in Sources */,
+				8B411F0C1CD8396E00623CAD /* ForTag.swift in Sources */,
+				8B411F141CD8396E00623CAD /* Parser.swift in Sources */,
+				8B411F0F1CD8396E00623CAD /* Inheritence.swift in Sources */,
+				8B411F101CD8396E00623CAD /* Lexer.swift in Sources */,
+				8B411F0A1CD8396E00623CAD /* Context.swift in Sources */,
+				8B411F181CD8396E00623CAD /* Variable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,7 +381,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B411F1A1CD8396F00623CAD /* Filters.swift in Sources */,
+				8B411F261CD8396F00623CAD /* Tokenizer.swift in Sources */,
+				8B411F211CD8396F00623CAD /* Node.swift in Sources */,
+				8B411F241CD8396F00623CAD /* Template.swift in Sources */,
+				8B411F201CD8396F00623CAD /* Namespace.swift in Sources */,
 				8B6D08DE1CD7FDFD00E91826 /* PathKit.swift in Sources */,
+				8B411F1D1CD8396F00623CAD /* Include.swift in Sources */,
+				8B411F221CD8396F00623CAD /* NowTag.swift in Sources */,
+				8B411F1C1CD8396F00623CAD /* IfTag.swift in Sources */,
+				8B411F251CD8396F00623CAD /* TemplateLoader.swift in Sources */,
+				8B411F1B1CD8396F00623CAD /* ForTag.swift in Sources */,
+				8B411F231CD8396F00623CAD /* Parser.swift in Sources */,
+				8B411F1E1CD8396F00623CAD /* Inheritence.swift in Sources */,
+				8B411F1F1CD8396F00623CAD /* Lexer.swift in Sources */,
+				8B411F191CD8396F00623CAD /* Context.swift in Sources */,
+				8B411F271CD8396F00623CAD /* Variable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -709,6 +769,7 @@
 				8B6D087D1CD7F9F500E91826 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8B6D08A81CD7FA2800E91826 /* Build configuration list for PBXNativeTarget "Stencil watchOS" */ = {
 			isa = XCConfigurationList;
@@ -717,6 +778,7 @@
 				8B6D08AA1CD7FA2800E91826 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8B6D08C21CD7FA4300E91826 /* Build configuration list for PBXNativeTarget "Stencil tvOS" */ = {
 			isa = XCConfigurationList;
@@ -725,6 +787,7 @@
 				8B6D08C41CD7FA4300E91826 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Stencil.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Stencil.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Stencil.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil iOS.xcscheme
+++ b/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8B6D08751CD7F9F500E91826"
-               BuildableName = "Stencil iOS.framework"
+               BuildableName = "Stencil.framework"
                BlueprintName = "Stencil iOS"
                ReferencedContainer = "container:Stencil.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B6D08751CD7F9F500E91826"
-            BuildableName = "Stencil iOS.framework"
+            BuildableName = "Stencil.framework"
             BlueprintName = "Stencil iOS"
             ReferencedContainer = "container:Stencil.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B6D08751CD7F9F500E91826"
-            BuildableName = "Stencil iOS.framework"
+            BuildableName = "Stencil.framework"
             BlueprintName = "Stencil iOS"
             ReferencedContainer = "container:Stencil.xcodeproj">
          </BuildableReference>

--- a/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil iOS.xcscheme
+++ b/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8B6D08751CD7F9F500E91826"
+               BuildableName = "Stencil iOS.framework"
+               BlueprintName = "Stencil iOS"
+               ReferencedContainer = "container:Stencil.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B6D08751CD7F9F500E91826"
+            BuildableName = "Stencil iOS.framework"
+            BlueprintName = "Stencil iOS"
+            ReferencedContainer = "container:Stencil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B6D08751CD7F9F500E91826"
+            BuildableName = "Stencil iOS.framework"
+            BlueprintName = "Stencil iOS"
+            ReferencedContainer = "container:Stencil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil tvOS.xcscheme
+++ b/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8B6D08BC1CD7FA4300E91826"
-               BuildableName = "Stencil tvOS.framework"
+               BuildableName = "Stencil.framework"
                BlueprintName = "Stencil tvOS"
                ReferencedContainer = "container:Stencil.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B6D08BC1CD7FA4300E91826"
-            BuildableName = "Stencil tvOS.framework"
+            BuildableName = "Stencil.framework"
             BlueprintName = "Stencil tvOS"
             ReferencedContainer = "container:Stencil.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B6D08BC1CD7FA4300E91826"
-            BuildableName = "Stencil tvOS.framework"
+            BuildableName = "Stencil.framework"
             BlueprintName = "Stencil tvOS"
             ReferencedContainer = "container:Stencil.xcodeproj">
          </BuildableReference>

--- a/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil tvOS.xcscheme
+++ b/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8B6D08BC1CD7FA4300E91826"
+               BuildableName = "Stencil tvOS.framework"
+               BlueprintName = "Stencil tvOS"
+               ReferencedContainer = "container:Stencil.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B6D08BC1CD7FA4300E91826"
+            BuildableName = "Stencil tvOS.framework"
+            BlueprintName = "Stencil tvOS"
+            ReferencedContainer = "container:Stencil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B6D08BC1CD7FA4300E91826"
+            BuildableName = "Stencil tvOS.framework"
+            BlueprintName = "Stencil tvOS"
+            ReferencedContainer = "container:Stencil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil watchOS.xcscheme
+++ b/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8B6D08A21CD7FA2800E91826"
+               BuildableName = "Stencil watchOS.framework"
+               BlueprintName = "Stencil watchOS"
+               ReferencedContainer = "container:Stencil.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B6D08A21CD7FA2800E91826"
+            BuildableName = "Stencil watchOS.framework"
+            BlueprintName = "Stencil watchOS"
+            ReferencedContainer = "container:Stencil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B6D08A21CD7FA2800E91826"
+            BuildableName = "Stencil watchOS.framework"
+            BlueprintName = "Stencil watchOS"
+            ReferencedContainer = "container:Stencil.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil watchOS.xcscheme
+++ b/Stencil.xcodeproj/xcshareddata/xcschemes/Stencil watchOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8B6D08A21CD7FA2800E91826"
-               BuildableName = "Stencil watchOS.framework"
+               BuildableName = "Stencil.framework"
                BlueprintName = "Stencil watchOS"
                ReferencedContainer = "container:Stencil.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B6D08A21CD7FA2800E91826"
-            BuildableName = "Stencil watchOS.framework"
+            BuildableName = "Stencil.framework"
             BlueprintName = "Stencil watchOS"
             ReferencedContainer = "container:Stencil.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B6D08A21CD7FA2800E91826"
-            BuildableName = "Stencil watchOS.framework"
+            BuildableName = "Stencil.framework"
             BlueprintName = "Stencil watchOS"
             ReferencedContainer = "container:Stencil.xcodeproj">
          </BuildableReference>

--- a/Stencil.xcworkspace/contents.xcworkspacedata
+++ b/Stencil.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:Stencil.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
Created an Xcode project, also added [PathKit](https://github.com/kylef/PathKit) as a file within the `Stencil` project because `PathKit` didn't have a dependency manager set up. Ideally though, it would be great to adjust the `Stencil` build script to pull in the `PathKit` source automatically. This PR is related to #27.

I made this [cross platform compatible with iOS, watchOS, and tvOS](http://basememara.com/creating-cross-platform-swift-frameworks-ios-watchos-tvos-via-carthage-cocoapods/). Let's wait to see next month what the best way to add macOS support ;)

Below is how the Xcode project structure was organized. Feel free to adjust as you see fit or discuss further.

<img width="437" alt="capturfiles_337" src="https://cloud.githubusercontent.com/assets/892152/14969095/71dbb6c0-108e-11e6-915f-39ccea77b3dc.png">

It worked when I tested this in my `Cartfile`: `github "ZamzamInc/Stencil"`! 👍 

![capturfiles_338](https://cloud.githubusercontent.com/assets/892152/14969130/a6ba36dc-108e-11e6-88a8-cc3beff9bf08.png)
