### PR TITLE
Templates from String Literals

### DIFF
--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -6,7 +6,7 @@ let NSFileNoSuchFileError = 4
 #endif
 
 /// A class representing a template
-open class Template {
+open class Template: ExpressibleByStringLiteral {
   let tokens: [Token]
 
   /// Create a template with the given name inside the given bundle
@@ -33,6 +33,21 @@ open class Template {
   public init(templateString:String) {
     let lexer = Lexer(templateString: templateString)
     tokens = lexer.tokenize()
+  }
+
+  // Create a template with a template string literal
+  public convenience required init(stringLiteral value:String) {
+    self.init(templateString: value)
+  }
+
+  // Create a template with a template string literal
+  public convenience required init(extendedGraphemeClusterLiteral value:StringLiteralType) {
+    self.init(stringLiteral: value)
+  }
+
+  // Create a template with a template string literal
+  public convenience required init(unicodeScalarLiteral value:StringLiteralType) {
+    self.init(stringLiteral: value)
   }
 
   /// Render the given template

--- a/Tests/StencilTests/TemplateSpec.swift
+++ b/Tests/StencilTests/TemplateSpec.swift
@@ -10,5 +10,12 @@ func testTemplate() {
       let result = try template.render(context)
       try expect(result) == "Hello World"
     }
+
+    $0.it("can render a template from a string literal") {
+        let context = Context(dictionary: [ "name": "Kyle" ])
+        let template: Template = "Hello World"
+        let result = try template.render(context)
+        try expect(result) == "Hello World"
+    }
   }
 }


### PR DESCRIPTION
Adds support for creating Templates from String Literals, to make dependent APIs more expressive.

```swift
func doSomething(_: Template) { ... }
doSomething("Hello {{ name }}")
```