### PR TITLE
Simple number literal parsing

### DIFF
--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -60,6 +60,11 @@ public struct Variable : Equatable, Resolvable {
       return variable[variable.characters.index(after: variable.startIndex) ..< variable.characters.index(before: variable.endIndex)]
     }
 
+    if let number = Float80(variable) {
+      // Number literal
+      return number
+    }
+
     for bit in lookup() {
       current = normalize(current)
 

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -45,6 +45,18 @@ func testVariable() {
       try expect(result) == "name"
     }
 
+    $0.it("can resolve an integer literal") {
+      let variable = Variable("5")
+      let result = try variable.resolve(context) as? Float80
+      try expect(result) == 5
+    }
+
+    $0.it("can resolve an float literal") {
+      let variable = Variable("3.14")
+      let result = try variable.resolve(context) as? Float80
+      try expect(result) == 3.14
+    }
+
     $0.it("can resolve a string variable") {
       let variable = Variable("name")
       let result = try variable.resolve(context) as? String


### PR DESCRIPTION
I hit this when trying to do the following:

    {% if items.count > 1 %}

Which doesn't work, because the rhs Variable evaluates to `nil`. This simply adds a number literal parser to allow this expression to work.

Small note: I'm purposefully not using a `NumberFormatter` to parse the number, because I want to ignore the user's locale for things like the decimal separator. Luckily enough, this simple way of parsing a number evaluates stuff like `2two` and `three3` to nil, so it really only parses actual numbers.