### PR TITLE
Allow subclassing templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
 - You can now use `{{ block.super }}` to render a super block from another `{%
   block %}`.
 
+- `Environment` allows you to provide a custom `Template` subclass, allowing
+  new template to use a specific subclass.
+
 ### Deprecations
 
 - `Template` initialisers have been deprecated in favour of using a template

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -1,9 +1,11 @@
 public struct Environment {
+  public let templateClass: Template.Type
   public let extensions: [Extension]
 
   public var loader: Loader?
 
-  public init(loader: Loader? = nil, extensions: [Extension]? = nil) {
+  public init(loader: Loader? = nil, extensions: [Extension]? = nil, templateClass: Template.Type = Template.self) {
+    self.templateClass = templateClass
     self.loader = loader
     self.extensions = [DefaultExtension()] + (extensions ?? [])
   }
@@ -30,7 +32,7 @@ public struct Environment {
   }
 
   public func renderTemplate(string: String, context: [String: Any]? = nil) throws -> String {
-    let template = Template(templateString: string, environment: self)
+    let template = templateClass.init(templateString: string, environment: self)
     return try template.render(context)
   }
 }

--- a/Sources/Loader.swift
+++ b/Sources/Loader.swift
@@ -51,7 +51,8 @@ public class FileSystemLoader: Loader, CustomStringConvertible {
         continue
       }
 
-      return try Template(path: templatePath, environment: environment, name: name)
+      let content: String = try templatePath.read()
+      return try environment.templateClass.init(templateString: content, environment: environment, name: name)
     }
 
     throw TemplateDoesNotExist(templateNames: [name], loader: self)
@@ -63,7 +64,8 @@ public class FileSystemLoader: Loader, CustomStringConvertible {
         let templatePath = try path.safeJoin(path: Path(templateName))
 
         if templatePath.exists {
-          return try Template(path: templatePath, environment: environment, name: templateName)
+          let content: String = try templatePath.read()
+          return try environment.templateClass.init(templateString: content, environment: environment, name: templateName)
         }
       }
     }

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -6,7 +6,7 @@ let NSFileNoSuchFileError = 4
 #endif
 
 /// A class representing a template
-public class Template: ExpressibleByStringLiteral {
+open class Template: ExpressibleByStringLiteral {
   let environment: Environment
   let tokens: [Token]
 
@@ -14,7 +14,7 @@ public class Template: ExpressibleByStringLiteral {
   public let name: String?
 
   /// Create a template with a template string
-  public init(templateString: String, environment: Environment? = nil, name: String? = nil) {
+  public required init(templateString: String, environment: Environment? = nil, name: String? = nil) {
     self.environment = environment ?? Environment()
     self.name = name
 
@@ -71,7 +71,7 @@ public class Template: ExpressibleByStringLiteral {
   }
 
   /// Render the given template
-  public func render(_ dictionary: [String: Any]? = nil) throws -> String {
+  open func render(_ dictionary: [String: Any]? = nil) throws -> String {
     return try render(Context(dictionary: dictionary, environment: environment))
   }
 }

--- a/Tests/StencilTests/EnvironmentSpec.swift
+++ b/Tests/StencilTests/EnvironmentSpec.swift
@@ -25,9 +25,15 @@ func testEnvironment() {
       let result = try environment.renderTemplate(name: "example.html")
       try expect(result) == "Hello World!"
     }
+
+    $0.it("allows you to provide a custom template class") {
+      let environment = Environment(loader: ExampleLoader(), templateClass: CustomTemplate.self)
+      let result = try environment.renderTemplate(string: "Hello World")
+
+      try expect(result) == "here"
+    }
   }
 }
-
 
 
 fileprivate class ExampleLoader: Loader {
@@ -37,5 +43,12 @@ fileprivate class ExampleLoader: Loader {
     }
 
     throw TemplateDoesNotExist(templateNames: [name], loader: self)
+  }
+}
+
+
+class CustomTemplate: Template {
+  override func render(_ dictionary: [String: Any]? = nil) throws -> String {
+    return "here"
   }
 }


### PR DESCRIPTION
In previous versions we allowed subclassing templates but this was removed in Stencil 0.7.0 (restore in 0.7.2).

This PR brings the functionality back for the next release, while also providing an API to allow you to provide a custom template class to Environment so templates can be loaded with it.

Example Usage:

```swift
class CustomTemplate: Template {
  override func render(_ dictionary: [String: Any]? = nil) throws -> String {
    return "here"
  }
}

let environment = Environment(templateClass: CustomTemplate.self)
let result = try environment.renderTemplate(string: "Hello World")
```

**NOTE:** *Custom templates can still be used as they were, but any templates loaded by the environment can now be customised.
