### PR TITLE
Support automatic escaping HTML

### DIFF
--- a/Sources/Extension.swift
+++ b/Sources/Extension.swift
@@ -57,6 +57,7 @@ class DefaultExtension: Extension {
     registerFilter("uppercase", filter: uppercase)
     registerFilter("lowercase", filter: lowercase)
     registerFilter("join", filter: joinFilter)
+    registerFilter("safe", filter: safeFilter)
   }
 }
 

--- a/Sources/Filters.swift
+++ b/Sources/Filters.swift
@@ -39,3 +39,8 @@ func joinFilter(value: Any?, arguments: [Any?]) throws -> Any? {
 
   return value
 }
+
+
+func safeFilter(value: Any?) throws -> Any? {
+  return escaped(html: stringify(value))
+}

--- a/Sources/HTML.swift
+++ b/Sources/HTML.swift
@@ -1,0 +1,26 @@
+public protocol HTMLString {
+  var html: String { get }
+}
+
+
+struct EscapedHTML: HTMLString, CustomStringConvertible {
+  let value: String
+
+  var html: String { return value }
+  var description: String { return value }
+}
+
+
+func escaped(html: String) -> HTMLString {
+  return EscapedHTML(value: html)
+}
+
+
+func escapeHTML(_ value: String) -> String {
+  return value
+    .replacingOccurrences(of: "&", with: "&amp;")
+    .replacingOccurrences(of: "'", with: "&39;")
+    .replacingOccurrences(of: "<", with: "&lt;")
+    .replacingOccurrences(of: ">", with: "&gt;")
+    .replacingOccurrences(of: "\"", with: "&quot;")
+}

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -70,10 +70,14 @@ public class VariableNode : NodeType {
 
   public func render(_ context: Context) throws -> String {
     let result = try variable.resolve(context)
-    return stringify(result)
+
+    if let result = result as? EscapedHTML {
+      return result.html
+    }
+
+    return escapeHTML(stringify(result))
   }
 }
-
 
 func stringify(_ result: Any?) -> String {
   if let result = result as? String {

--- a/Tests/StencilTests/FilterSpec.swift
+++ b/Tests/StencilTests/FilterSpec.swift
@@ -147,4 +147,13 @@ func testFilter() {
       try expect(result) == "OneTwo"
     }
   }
+
+  describe("safe filter") {
+    let template = Template(templateString: "{{ \"<'>\"|safe }}")
+
+    $0.it("prevents auto escaping") {
+      let result = try template.render()
+      try expect(result) == "<'>"
+    }
+  }
 }

--- a/Tests/StencilTests/NodeSpec.swift
+++ b/Tests/StencilTests/NodeSpec.swift
@@ -12,6 +12,7 @@ class ErrorNode : NodeType {
 func testNode() {
   describe("Node") {
     let context = Context(dictionary: [
+      "title": escaped(html: "'Hello World'"),
       "name": "Kyle",
       "age": 27,
       "items": [1, 2, 3],
@@ -33,6 +34,18 @@ func testNode() {
       $0.it("resolves and renders a non string variable") {
         let node = VariableNode(variable: Variable("age"))
         try expect(try node.render(context)) == "27"
+      }
+
+      $0.describe("escaping") {
+        $0.it("automatically escapes unescaped html") {
+          let node = VariableNode(variable: Variable("\"'Hello World'\""))
+          try expect(try node.render(context)) == "&39;Hello World&39;"
+        }
+
+        $0.it("doesn't double escape already escaped HTML") {
+          let node = VariableNode(variable: Variable("title"))
+          try expect(try node.render(context)) == "'Hello World'"
+        }
       }
     }
 

--- a/docs/builtins.rst
+++ b/docs/builtins.rst
@@ -286,3 +286,20 @@ Join an array of items.
     {{ value|join:", " }}
 
 .. note:: The value MUST be an array.
+
+``safe``
+~~~~~~~~
+
+Marks a value as safe and thus prevents the value from being automatically
+escaped.
+
+.. code-block:: html+django
+
+    {{ name|safe }}
+
+Other filters may remove the safe state, for example filtering through `safe`
+and then `lowercase` will result in an unsafe lowercased string.
+
+.. code-block:: html+django
+
+    {{ name|safe|lowercase }}


### PR DESCRIPTION
This pull request is the first step in implementing auto escaping.

### Why?

Most users of Stencil are going to be using Stencil as a HTML tempting language, and subsequently it should provide auto escaping of HTML for XSS prevention. A Stencil template author should not have to think about XSS or escaping as it will be handled automatically.

### Should auto escape be enable by default?

I've been thinking a lot about this, and leaning towards auto escaping to be off by default. However any web frameworks should create an environment with auto escaping enabled for rendering templates.

It may make sense for autoescaping HTML to be enable by default because most cases users will be using Templates with HTML.

### How should the auto escape setting in Environment work?

Jinja2 has an approach of allowing users to provide a function which can be used to determine if auto escape can be enabled. The value can also be set to False/True to force.

```python
def guess_autoescape(template_name):
    if template_name is None or '.' not in template_name:
        return False

    ext = template_name.rsplit('.', 1)[1]
    return ext in ('html', 'htm', 'xml')
```

This seems useful, especially for web frameworks where they may want to provide this exact behaviour of escaping HTML based on a `.html` extension. So that if there was `.txt` templates for example an email template it would not be escaped.

### Allowing users to escape in any format

We shouldn't limit the API to only allow HTML autoescape, users should be able to write custom escaping rules for other content types. Most of the similiar template languages to Stencil don't allow serialising custom formats.

### Allowing users to mark a value as already escaped

We provide the `HTMLEscaped` protocol which allows you to provide a `html` property which will return an already escaped string. This might be useful if you need to include HTML inside a variable such as:

```html+django
{{ form }}
```

```swift
class Form: HTMLEscaped {
  // fields
  
  var html: String {
    return "<ul><li><input type="text" name="name"></li></ul>"
  }
}
```

Where form returns HTML representation of a HTML form.

There is also a template filter which can be used to wrap a value in the escaped protocol.

```html+django
{{ value|safe }}
```

Force escaping:

```html+django
{{ value|escape }}
```

Django also provides an `{% autoescape on/off %}{% endautoescape %}` block so users can enable/disable auto escaping in a scope.

---

This pull request is not yet ready. The current state is to force HTML auto escaping, it should become optional with custom formats.