### PR TITLE
Trim newlines

### DIFF
--- a/Sources/Lexer.swift
+++ b/Sources/Lexer.swift
@@ -62,8 +62,7 @@ struct Lexer {
                     trimmedTokens[index + 1] = .text(value: trimmedNextText)
                 }
                 else if case .text(let previousText) = tokens[index - 1],
-                    previousText.range(of: "\n[\t ]*$", options: .regularExpression, range: nil, locale: nil) != nil,
-                    !(index == tokens.count - 2 && nextText == "\n") {
+                    previousText.range(of: "\n[\t ]*$", options: .regularExpression, range: nil, locale: nil) != nil {
                     let trimmedPreviousText = trimmedTokens[index - 1].contents.replacingOccurrences(of: "[\t ]*$", with: "", options: .regularExpression, range: nil)
                     let trimmedNextText = trimmedTokens[index + 1].contents.replacingOccurrences(of: trimPattern, with: "", options: .regularExpression, range: nil)
                     trimmedTokens[index - 1] = .text(value: trimmedPreviousText)

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -80,8 +80,7 @@ func testForNode() {
 
       let fixture = "" +
         "- Migrating from OCUnit to XCTest by Kyle Fuller.\n" +
-        "- Memory Management with ARC by Kyle Fuller.\n" +
-        "\n"
+        "- Memory Management with ARC by Kyle Fuller.\n"
 
       try expect(result) == fixture
     }

--- a/Tests/StencilTests/StencilSpec.swift
+++ b/Tests/StencilTests/StencilSpec.swift
@@ -55,6 +55,43 @@ func testStencil() {
       try expect(result) == fixture
     }
 
+    $0.it("can remove newlines from blocks on their own line") {
+
+        let templateString = "{% for item in items %}\n" +
+            "   {{item}}\n" +
+            "{% endfor %}\n"
+
+        let context = ["items": ["item 1", "item 2"]]
+
+        let template = Template(templateString: templateString)
+        let result = try template.render(context)
+
+        let fixture =
+            "   item 1\n" +
+            "   item 2\n"
+        
+        try expect(result) == fixture
+    }
+
+    $0.it("can remove whitespace and newlines from blocks on their own line") {
+
+        let templateString = "Items:\n" +
+            "   {% for item in items %}\n" +
+            "       {{item}}\n" +
+            "   {% endfor %}\n"
+
+        let context = ["items": ["item 1", "item 2"]]
+
+        let template = Template(templateString: templateString)
+        let result = try template.render(context)
+
+        let fixture = "Items:\n" +
+            "       item 1\n" +
+            "       item 2\n"
+
+        try expect(result) == fixture
+    }
+
     $0.it("can render a custom template tag") {
       let result = try environment.renderTemplate(string: "{% customtag %}")
       try expect(result) == "Hello World"

--- a/Tests/StencilTests/StencilSpec.swift
+++ b/Tests/StencilTests/StencilSpec.swift
@@ -50,8 +50,7 @@ func testStencil() {
       let fixture = "There are 2 articles.\n" +
         "\n" +
         "    - Migrating from OCUnit to XCTest by Kyle Fuller.\n" +
-        "    - Memory Management with ARC by Kyle Fuller.\n" +
-        "\n"
+        "    - Memory Management with ARC by Kyle Fuller.\n"
 
       try expect(result) == fixture
     }


### PR DESCRIPTION
This fixes #22 and is an alternative to #32 
The lexer removes white space and trailing newlines from block tokens if they are on their own line.
```
{% for item in items %}
- {{item.name}}
{% endfor %}
```
will now be rendered
```
- item 1
- item 2
- item 3
```