### PR TITLE
Fixed parsing several filter arguments with quotes

### DIFF
--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -7,14 +7,18 @@ extension String {
     var word = ""
     var components: [String] = []
     var separate: Character = separator
+    var singleQuoteCount = 0
+    var doubleQuoteCount = 0
 
     for character in self.characters {
+      if character == "'" { singleQuoteCount += 1 }
+      else if character == "\"" { doubleQuoteCount += 1 }
+
       if character == separate {
+
         if separate != separator {
           word.append(separate)
-        }
-
-        if !word.isEmpty {
+        } else if singleQuoteCount % 2 == 0 && doubleQuoteCount % 2 == 0 && !word.isEmpty {
           components.append(word)
           word = ""
         }

--- a/Tests/StencilTests/FilterSpec.swift
+++ b/Tests/StencilTests/FilterSpec.swift
@@ -22,8 +22,8 @@ func testFilter() {
       try expect(result) == "Kyle Kyle"
     }
 
-    $0.it("allows you to register a custom filter which accepts arguments") {
-      let template = Template(templateString: "{{ name|repeat:'value' }}")
+    $0.it("allows you to register a custom filter which accepts single argument") {
+      let template = Template(templateString: "{{ name|repeat:'value1, \"value2\"' }}")
 
       let repeatExtension = Extension()
       repeatExtension.registerFilter("repeat") { value, arguments in
@@ -35,7 +35,23 @@ func testFilter() {
       }
 
       let result = try template.render(Context(dictionary: context, environment: Environment(extensions: [repeatExtension])))
-      try expect(result) == "Kyle Kyle with args value"
+      try expect(result) == "Kyle Kyle with args value1, \"value2\""
+    }
+
+    $0.it("allows you to register a custom filter which accepts several arguments") {
+        let template = Template(templateString: "{{ name|repeat:'value\"1\"',\"value'2'\",'(key, value)' }}")
+
+        let repeatExtension = Extension()
+        repeatExtension.registerFilter("repeat") { value, arguments in
+            if !arguments.isEmpty {
+                return "\(value!) \(value!) with args 0: \(arguments[0]!), 1: \(arguments[1]!), 2: \(arguments[2]!)"
+            }
+
+            return nil
+        }
+
+        let result = try template.render(Context(dictionary: context, environment: Environment(extensions: [repeatExtension])))
+        try expect(result) == "Kyle Kyle with args 0: value\"1\", 1: value'2', 2: (key, value)"
     }
 
     $0.it("allows you to register a custom which throws") {


### PR DESCRIPTION
Current version (latest master) incorrectly parses subsequent filter parameters that use quotes, i.e. `name|replace:\"foo\",\"bar\"` will give three arguments instead of 2.

Internally it creates filter expression with three variables, `"foo"`, `":"` and `"bar"`. It inserts unneeded colon because when splitting filter token by colon it splits it into `replace`, `"foo"` and `,"bar"`, then it drops the first and joins all others with colon. That gives arguments string `"foo":,"bar"`. Then it also incorrectly splits it into `"foo"`, `:` and `"bar"`.

With this fix token is correctly split  into `replace`, `"foo","bar"` and then arguments are split into `"foo"` and `"bar"`