### PR TITLE
Handle double optionals

### DIFF
--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -99,9 +99,15 @@ public struct Variable : Equatable, Resolvable {
         let mirror = Mirror(reflecting: value)
         current = mirror.descendant(bit)
 
-        if current == nil {
-          return nil
-        }
+        // handle the possiblity of double optionals
+        if let obj = current {
+            let r = Mirror(reflecting: obj)
+            if let display = r.displayStyle, display == .optional {
+                current = r.descendant("some")
+            }
+        } else {
+            return nil
+        }        
       } else {
         return nil
       }

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -26,7 +26,8 @@ func testVariable() {
       "profiles": [
         "github": "kylef",
       ],
-      "article": Article(author: Person(name: "Kyle"))
+      "article": Article(author: Person(name: "Kyle")),
+      "doubleOptional": Optional<Any>(Optional<Int>(1)) as Any
     ])
 
 #if os(OSX)
@@ -105,6 +106,12 @@ func testVariable() {
       let variable = Variable("article.author.name")
       let result = try variable.resolve(context) as? String
       try expect(result) == "Kyle"
+    }
+    
+    $0.it("can resolve double optionals") {
+        let variable = Variable("doubleOptional")
+        let result = try variable.resolve(context) as? Int
+        try expect(result) == 1
     }
 
 #if os(OSX)


### PR DESCRIPTION
When using Stencil with Vapor, I found that the id field of model objects would resolve to a double optional within Stencil. The id field is defined as Node? and the current variable here is defined as Any?, so what it ends up being is Optional(Optional(Node)). The code I added below handles that case.