### PR TITLE
Dictionary tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `for` block now allows you to iterate over array of tuples or dictionaries.
 
   ```html+django
-  {% for key, value in thing %}
+  {% for key,value in thing %}
     <li>{{ key }}: {{ value }}</li>
   {% endfor %}
   ```

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -74,7 +74,11 @@ public struct Variable : Equatable, Resolvable {
       if let context = current as? Context {
         current = context[bit]
       } else if let dictionary = current as? [String: Any] {
-        current = dictionary[bit]
+        if bit == "count" && dictionary[bit] == nil {
+          current = dictionary.count
+        } else {
+          current = dictionary[bit]
+        }
       } else if let array = current as? [Any] {
         if let index = Int(bit) {
           if index >= 0 && index < array.count {

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -105,6 +105,18 @@ func testForNode() {
       try expect(result) == fixture
     }
 
+    $0.it("can iterate over dictionary") {
+      let templateString = "{% for key,value in dict %}" +
+        "{{ key }}: {{ value }}\n" +
+        "{% endfor %}\n"
+
+      let template = Template(templateString: templateString)
+      let result = try template.render(context)
+
+      let fixture = "one: I\ntwo: II\n\n"
+      try expect(result) == fixture
+    }
+
     $0.it("renders supports iterating over dictionary") {
       let nodes: [NodeType] = [VariableNode(variable: "key")]
       let emptyNodes: [NodeType] = [TextNode(text: "empty")]

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -26,6 +26,9 @@ func testVariable() {
       "profiles": [
         "github": "kylef",
       ],
+      "counter": [
+        "count": "kylef",
+        ],
       "article": Article(author: Person(name: "Kyle"))
     ])
 
@@ -105,6 +108,18 @@ func testVariable() {
       let variable = Variable("article.author.name")
       let result = try variable.resolve(context) as? String
       try expect(result) == "Kyle"
+    }
+
+    $0.it("can get the count of a dictionary") {
+      let variable = Variable("profiles.count")
+      let result = try variable.resolve(context) as? Int
+      try expect(result) == 1
+    }
+
+    $0.it("can get the value of a count key in a dictionary") {
+      let variable = Variable("counter.count")
+      let result = try variable.resolve(context) as? String
+      try expect(result) == "kylef"
     }
 
 #if os(OSX)


### PR DESCRIPTION
This allows you to access the count of a dictionary. If the dictionary happens to have a value at the key "count" it will return that value instead. Includes tests

I also noticed that the dictionary for loop doesn't support a space after the comma, so that this is supported:
```
{% for key,value in thing %}
```
but this is not:
```
{% for key, value in thing %}
```
This just updates the changelog to reflect this discrepancy until it is fixed. Once it is, the `can iterate over dictionary` test can have a space added