### PR TITLE
[Review] Include block improvements

### DIFF
--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -32,7 +32,11 @@ class IncludeNode : NodeType, Indented {
     return try context.push(dictionary: subContext) {
       var content = try template.render(context)
       if !indent.isEmpty {
-        content = content.replacingOccurrences(of: "\n", with: "\n\(indent)")
+        var lines = content.components(separatedBy: "\n")
+        content = lines.removeFirst()
+        if !lines.isEmpty {
+          content += "\n" + lines.map { $0.isEmpty ? "" : "\(indent)\($0)"}.joined(separator: "\n")
+        }
       }
       return content
     }

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -1,8 +1,9 @@
 import PathKit
 
 
-class IncludeNode : NodeType {
+class IncludeNode : NodeType, Indented {
   let templateName: Variable
+  var indent: String = ""
 
   class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
     let bits = token.components()
@@ -26,7 +27,11 @@ class IncludeNode : NodeType {
     let template = try context.environment.loadTemplate(name: templateName)
 
     return try context.push {
-      return try template.render(context)
+      var content = try template.render(context)
+      if !indent.isEmpty {
+        content = content.replacingOccurrences(of: "\n", with: "\n\(indent)")
+      }
+      return content
     }
   }
 }

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -3,20 +3,22 @@ import PathKit
 
 class IncludeNode : NodeType, Indented {
   let templateName: Variable
+  let includeContext: String?
   var indent: String = ""
 
   class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
     let bits = token.components()
 
-    guard bits.count == 2 else {
-      throw TemplateSyntaxError("'include' tag takes one argument, the template file to be included")
+    guard bits.count == 2 || (bits.count == 4 && bits[2] == "using") else {
+      throw TemplateSyntaxError("'include' tag requires one argument, the template file to be included. Another optional argument can be used to specify the context that will be passed to the included file, using the format \"using myContext\"")
     }
 
-    return IncludeNode(templateName: Variable(bits[1]))
+    return IncludeNode(templateName: Variable(bits[1]), includeContext: bits.count == 4 ? bits[3] : nil)
   }
 
-  init(templateName: Variable) {
+  init(templateName: Variable, includeContext: String? = nil) {
     self.templateName = templateName
+    self.includeContext = includeContext
   }
 
   func render(_ context: Context) throws -> String {
@@ -26,7 +28,8 @@ class IncludeNode : NodeType, Indented {
 
     let template = try context.environment.loadTemplate(name: templateName)
 
-    return try context.push {
+    let subContext = includeContext.flatMap{ context[$0] as? [String: Any] }
+    return try context.push(dictionary: subContext) {
       var content = try template.render(context)
       if !indent.isEmpty {
         content = content.replacingOccurrences(of: "\n", with: "\n\(indent)")

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -56,7 +56,7 @@ public class TokenParser {
           if nodes.count > 1,
             let indentedNode = nodes[nodes.count - 1] as? Indented,
             let textNode = nodes[nodes.count - 2] as? TextNode {
-            indentedNode.indent = textNode.text.trimmingCharacters(in: CharacterSet.whitespaces.inverted)
+            indentedNode.indent = textNode.text.components(separatedBy: "\n").last!.trimmingCharacters(in: CharacterSet.whitespaces.inverted)
           }
         }
       case .comment:

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public func until(_ tags: [String]) -> ((TokenParser, Token) -> Bool) {
   return { parser, token in
     if let name = token.components().first {
@@ -50,6 +52,12 @@ public class TokenParser {
         if let tag = token.components().first {
           let parser = try findTag(name: tag)
           nodes.append(try parser(self, token))
+
+          if nodes.count > 1,
+            let indentedNode = nodes[nodes.count - 1] as? Indented,
+            let textNode = nodes[nodes.count - 2] as? TextNode {
+            indentedNode.indent = textNode.text.trimmingCharacters(in: CharacterSet.whitespaces.inverted)
+          }
         }
       case .comment:
         continue
@@ -94,5 +102,8 @@ public class TokenParser {
   public func compileFilter(_ token: String) throws -> Resolvable {
     return try FilterExpression(token: token, parser: self)
   }
+}
 
+protocol Indented: class {
+  var indent: String { get set }
 }

--- a/Tests/StencilTests/IncludeSpec.swift
+++ b/Tests/StencilTests/IncludeSpec.swift
@@ -61,7 +61,7 @@ func testInclude() {
           let template = Template(templateString: "Include:\n\t{% include \"include.html\" %}\nnewline")
           let context = Context(dictionary: ["items": [["name":"one"], ["name": "two"]]], environment: environment)
           let value = try template.render(context)
-          try expect(value) == "Include:\n\tI have 2 items:\n\t  one\n\t  two\n\t\nnewline"
+          try expect(value) == "Include:\n\tI have 2 items:\n\t  one\n\t  two\n\nnewline"
       }
 
       $0.it("successfully passes context") {

--- a/Tests/StencilTests/IncludeSpec.swift
+++ b/Tests/StencilTests/IncludeSpec.swift
@@ -58,10 +58,10 @@ func testInclude() {
       }
 
       $0.it("successfully indents included content") {
-          let template = Template(templateString: "Include:\n\t{% include \"include.html\" %}\nnewline")
+          let template = Template(templateString: "Include:\n \n\t{% include \"include.html\" %}\nnewline")
           let context = Context(dictionary: ["items": [["name":"one"], ["name": "two"]]], environment: environment)
           let value = try template.render(context)
-          try expect(value) == "Include:\n\tI have 2 items:\n\t  one\n\t  two\n\nnewline"
+          try expect(value) == "Include:\n \n\tI have 2 items:\n\t  one\n\t  two\n\nnewline"
       }
 
       $0.it("successfully passes context") {

--- a/Tests/StencilTests/IncludeSpec.swift
+++ b/Tests/StencilTests/IncludeSpec.swift
@@ -14,7 +14,7 @@ func testInclude() {
         let tokens: [Token] = [ .block(value: "include") ]
         let parser = TokenParser(tokens: tokens, environment: Environment())
 
-        let error = TemplateSyntaxError("'include' tag takes one argument, the template file to be included")
+        let error = TemplateSyntaxError("'include' tag requires one argument, the template file to be included. Another optional argument can be used to specify the context that will be passed to the included file, using the format \"using myContext\"")
         try expect(try parser.parse()).toThrow(error)
       }
 
@@ -62,6 +62,13 @@ func testInclude() {
           let context = Context(dictionary: ["items": [["name":"one"], ["name": "two"]]], environment: environment)
           let value = try template.render(context)
           try expect(value) == "Include:\n\tI have 2 items:\n\t  one\n\t  two\n\t\nnewline"
+      }
+
+      $0.it("successfully passes context") {
+        let template = Template(templateString: "{% include \"test.html\" using child %}")
+        let context = Context(dictionary: ["child": ["target": "World"]], environment: environment)
+        let value = try template.render(context)
+        try expect(value) == "Hello World!"
       }
     }
   }

--- a/Tests/StencilTests/IncludeSpec.swift
+++ b/Tests/StencilTests/IncludeSpec.swift
@@ -56,6 +56,13 @@ func testInclude() {
         let value = try node.render(context)
         try expect(value) == "Hello World!"
       }
+
+      $0.it("successfully indents included content") {
+          let template = Template(templateString: "Include:\n\t{% include \"include.html\" %}\nnewline")
+          let context = Context(dictionary: ["items": [["name":"one"], ["name": "two"]]], environment: environment)
+          let value = try template.render(context)
+          try expect(value) == "Include:\n\tI have 2 items:\n\t  one\n\t  two\n\t\nnewline"
+      }
     }
   }
 }

--- a/Tests/StencilTests/fixtures/include.html
+++ b/Tests/StencilTests/fixtures/include.html
@@ -1,0 +1,2 @@
+I have {{ items.count }} items:{% for item in items %}
+  {{ item.name }}{% endfor %}


### PR DESCRIPTION
Fixes #95

This adds 2 features to the `include` block including tests:
1. If the include block is indented with any whitespace, any content in the included file is indented by the same amount
2. Optional argument `using` which lets you pass a context to the included file using the format: `{% include "myFile.stencil" using myContext %}`