### PR TITLE
Make extensions mutable

### DIFF
--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -1,6 +1,6 @@
 public struct Environment {
   public let templateClass: Template.Type
-  public let extensions: [Extension]
+  public var extensions: [Extension]
 
   public var loader: Loader?
 


### PR DESCRIPTION
Making extensions mutable allows for a better user experience when a user of my module needs to add extensions on top of the extensions I've already registered. Fixes #125 