### PR TITLE
Add range support for for tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .conche/
 .build/
 Packages/
+Package.resolved

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -90,6 +90,10 @@ class ForNode : NodeType {
       values = dictionary.map { ($0.key, $0.value) }
     } else if let array = resolved as? [Any] {
       values = array
+    } else if let range = resolved as? CountableClosedRange<Int> {
+      values = Array(range)
+    } else if let range = resolved as? CountableRange<Int> {
+      values = Array(range)
     } else {
       values = []
     }

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -37,6 +37,22 @@ func testForNode() {
       try expect(try node.render(any_context)) == "123"
     }
 
+    $0.it("renders a context variable of type CountableClosedRange<Int>") {
+      let context = Context(dictionary: ["range": 1...3])
+      let nodes: [NodeType] = [VariableNode(variable: "item")]
+      let node = ForNode(resolvable: Variable("range"), loopVariables: ["item"], nodes: nodes, emptyNodes: [])
+
+      try expect(try node.render(context)) == "123"
+    }
+
+    $0.it("renders a context variable of type CountableRange<Int>") {
+      let context = Context(dictionary: ["range": 1..<4])
+      let nodes: [NodeType] = [VariableNode(variable: "item")]
+      let node = ForNode(resolvable: Variable("range"), loopVariables: ["item"], nodes: nodes, emptyNodes: [])
+
+      try expect(try node.render(context)) == "123"
+    }
+
 #if os(OSX)
     $0.it("renders a context variable of type NSArray") {
       let nsarray_context = Context(dictionary: [


### PR DESCRIPTION
This adds support for `CountableRange<Int>` and `CountableClosedRange<Int>` to the for tag in a simplistic manner. I think a better approach would be to [have this `values` variable](https://github.com/bfad/Stencil/blob/64571464d93a6808c6493a99f95bf7828f4a3190/Sources/ForTag.swift#L87) be a type that could be supported by both `Array` and the ranges. (Part of the point of using a range over an array is to save memory.) I'm not entirely sure how to do this though I did try declaring it to be a `Sequence` which didn't work out.