### PR TITLE
Make Template render(_ context: Context) public

### DIFF
--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -63,7 +63,7 @@ open class Template: ExpressibleByStringLiteral {
   }
 
   /// Render the given template with a context
-  func render(_ context: Context) throws -> String {
+  public func render(_ context: Context) throws -> String {
     let context = context
     let parser = TokenParser(tokens: tokens, environment: context.environment)
     let nodes = try parser.parse()


### PR DESCRIPTION
I'd like to make this function public so I can call it from my library that consumes Stencil. It's necessary for a custom node I implemented.