### PR TITLE
fixed checking values for nil when using mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   incorrect amount of arguments.
 - Fixes a potential crash when using incomplete tokens in a template for
   example, `{%%}` or `{{}}`.
+- Fixes evaluating nil properties as true
 
 
 ## 0.9.0

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -101,6 +101,10 @@ public struct Variable : Equatable, Resolvable {
 
         if current == nil {
           return nil
+          // mirror returns non-nil value even for nil-containing properties
+          // so we have to check if its value is actually nil or not
+        } else if let current = current, String(describing: current) == "nil" {
+          return nil
         }
       } else {
         return nil

--- a/Tests/StencilTests/IfNodeSpec.swift
+++ b/Tests/StencilTests/IfNodeSpec.swift
@@ -254,7 +254,7 @@ func testIfNode() {
         try expect(result) == "true"
     }
     
-    $0.it("supports nil as value") {
+    $0.it("evaluates nil properties as false") {
       let tokens: [Token] = [
         .block(value: "if instance.value"),
         .text(value: "true"),

--- a/Tests/StencilTests/IfNodeSpec.swift
+++ b/Tests/StencilTests/IfNodeSpec.swift
@@ -253,5 +253,22 @@ func testIfNode() {
         let result = try renderNodes(nodes, Context(dictionary: ["value": "test"]))
         try expect(result) == "true"
     }
+    
+    $0.it("supports nil as value") {
+      let tokens: [Token] = [
+        .block(value: "if instance.value"),
+        .text(value: "true"),
+        .block(value: "endif")
+      ]
+      
+      let parser = TokenParser(tokens: tokens, environment: Environment())
+      let nodes = try parser.parse()
+      
+      struct SomeType {
+        let value: String? = nil
+      }
+      let result = try renderNodes(nodes, Context(dictionary: ["instance": SomeType()]))
+      try expect(result) == ""
+    }
   }
 }


### PR DESCRIPTION
Resolves #140 
@kylef couldn't find a simpler way to check for nil underlying values. There is a way to do that using custom box protocol, but it requires extending both Option and IUO types, but string approach works for both of them already.