### PR TITLE
Fix Swift 4 compilation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
     - os: osx
       osx_image: xcode9
       env: SWIFT_VERSION=4.0
+    - os: osx
+      osx_image: xcode9.1
+      env: SWIFT_VERSION=4.0
     - os: linux
       env: SWIFT_VERSION=3.1.1
     - os: linux

--- a/Sources/Lexer.swift
+++ b/Sources/Lexer.swift
@@ -10,7 +10,7 @@ struct Lexer {
       guard string.characters.count > 4 else { return "" }
       let start = string.index(string.startIndex, offsetBy: 2)
       let end = string.index(string.endIndex, offsetBy: -2)
-      return string[start..<end].trim(character: " ")
+      return String(string[start..<end]).trim(character: " ")
     }
 
     if string.hasPrefix("{{") {
@@ -149,6 +149,6 @@ extension String {
   func trim(character: Character) -> String {
     let first = findFirstNot(character: character) ?? startIndex
     let last = findLastNot(character: character) ?? endIndex
-    return self[first..<last]
+    return String(self[first..<last])
   }
 }


### PR DESCRIPTION
Installing 0.10.0 on Xcode 9.1/Swift 4 results in a compilation error to the effect of "Swift 4 subscripts returning string obsoleted". Not sure if this was a more recent change in 9.1, since I see you're already testing on Xcode 9.