### PR TITLE
Add a protocol for keying into variables.

### DIFF
--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -56,6 +56,9 @@ public protocol Resolvable {
   func resolve(_ context: Context) throws -> Any?
 }
 
+public protocol RenderKeyed {
+  func value( forRenderKey key: String) -> Any?
+}
 
 public class VariableNode : NodeType {
   public let variable: Resolvable

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -93,14 +93,14 @@ public struct Variable : Equatable, Resolvable {
         } else if bit == "count" {
           current = array.count
         }
+      } else if let keyed = current as? RenderKeyed {
+        current = keyed.value(forRenderKey: bit)
       } else if let object = current as? NSObject {  // NSKeyValueCoding
 #if os(Linux)
         return nil
 #else
         current = object.value(forKey: bit)
 #endif
-      } else if let keyed = current as? RenderKeyed {
-        current = keyed.value(forRenderKey: bit)
       } else if let value = current {
         let mirror = Mirror(reflecting: value)
         current = mirror.descendant(bit)

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -99,6 +99,8 @@ public struct Variable : Equatable, Resolvable {
 #else
         current = object.value(forKey: bit)
 #endif
+      } else if let keyed = current as? RenderKeyed {
+        current = keyed.value(forRenderKey: bit)
       } else if let value = current {
         let mirror = Mirror(reflecting: value)
         current = mirror.descendant(bit)

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -21,7 +21,8 @@ following lookup:
 - Context lookup
 - Dictionary lookup
 - Array lookup (first, last, count, index)
-- Key value coding lookup
+- RenderKeyed protocol lookup
+- Key value coding lookup (macos only)
 - Type introspection
 
 For example, if `people` was an array:
@@ -30,6 +31,12 @@ For example, if `people` was an array:
 
     There are {{ people.count }} people. {{ people.first }} is the first
     person, followed by {{ people.1 }}.
+
+If a variable implements the RenderKeyed protocol it can provide a
+value for a String key, much like key value coding, but it works on
+all operating systems and allows you to decouple the names used in
+the templates from the Swift implementation. The RenderKeyed protocol
+requires a single function: `: value(forRenderKey:String)->Any?`
 
 Filters
 ~~~~~~~


### PR DESCRIPTION
On non-macOS platforms key value coding can not be used to extract values from variables. The introspection strategy works, but only for fields of the topmost class. Superclass fields are not visible. This makes any kind of hierarchical classes problematic.

This PR adds a protocol with a single function which works like the key value coding `func value(key)->Any?`. 

The advantages are:

 - cross platform safe
 - allows the Stencil templates to use names which are different from the internal implementation names of the underlying Swift files
 - allow the Swift types to limit what they export to the template engine
 - faster than KVC or introspection

I've placed the RenderKeyed protocol above KVC or it would not be used on macOS.
