### PR TITLE
For loop improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - added support for iterating over tuple elements and subscripting it with label or index
   - added support for iterating array with index and value
   - fixed using spaces between loop variables
-  - added support for subscripting dictionary using loop variable for key
+  - added support for subscripting arrays and dictionaries using loop variables for index or key
   - added `break` and `continue` tags to break or continue current loop
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - added support for iterating array with index and value
   - fixed using spaces between loop variables
   - added support for subscripting dictionary using loop variable for key
+  - added `break` and `continue` tags to break or continue current loop
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Enhancements
 
 - Added support for resolving superclass properties for not-NSObject subclasses
+- Various improvements for for tag:
+  - added support for iterating over tuple elements and subscripting it with label or index
+  - added support for iterating array with index and value
+  - fixed using spaces between loop variables
+  - added support for subscripting dictionary using loop variable for key
+
 
 ### Bug Fixes
 

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -4,7 +4,7 @@ public class Context {
 
   public let environment: Environment
 
-  init(dictionary: [String: Any]? = nil, environment: Environment? = nil) {
+  init(dictionary: [String: Any?]? = nil, environment: Environment? = nil) {
     if let dictionary = dictionary {
       dictionaries = [dictionary]
     } else {
@@ -37,7 +37,7 @@ public class Context {
   }
 
   /// Push a new level into the Context
-  fileprivate func push(_ dictionary: [String: Any]? = nil) {
+  fileprivate func push(_ dictionary: [String: Any?]? = nil) {
     dictionaries.append(dictionary ?? [:])
   }
 
@@ -47,14 +47,14 @@ public class Context {
   }
 
   /// Push a new level onto the context for the duration of the execution of the given closure
-  public func push<Result>(dictionary: [String: Any]? = nil, closure: (() throws -> Result)) rethrows -> Result {
+  public func push<Result>(dictionary: [String: Any?]? = nil, closure: (() throws -> Result)) rethrows -> Result {
     push(dictionary)
     defer { _ = pop() }
     return try closure()
   }
 
-  public func flatten() -> [String: Any] {
-    var accumulator: [String: Any] = [:]
+  public func flatten() -> [String: Any?] {
+    var accumulator: [String: Any?] = [:]
 
     for dictionary in dictionaries {
       for (key, value) in dictionary {

--- a/Sources/Extension.swift
+++ b/Sources/Extension.swift
@@ -40,6 +40,8 @@ class DefaultExtension: Extension {
 
   fileprivate func registerDefaultTags() {
     registerTag("for", parser: ForNode.parse)
+    registerTag("break", parser: LoopTerminationNode.parse)
+    registerTag("continue", parser: LoopTerminationNode.parse)
     registerTag("if", parser: IfNode.parse)
     registerTag("ifnot", parser: IfNode.parse_ifnot)
 #if !os(Linux)

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -89,14 +89,18 @@ class ForNode : NodeType {
   }
 
   func render(_ context: Context) throws -> String {
-    let resolved = try resolvable.resolve(context)
+    guard let resolved = try resolvable.resolve(context) else { return "" }
 
     var values: [Any]
 
     if let dictionary = resolved as? [String: Any], !dictionary.isEmpty {
       values = dictionary.map { ($0.key, $0.value) }
     } else if let array = resolved as? [Any] {
-      values = array
+      if loopVariables.count == 2 {
+        values = array.enumerated().map({ ($0.offset, $0.element) })
+      } else {
+        values = array
+      }
     } else if let range = resolved as? CountableClosedRange<Int> {
       values = Array(range)
     } else if let range = resolved as? CountableRange<Int> {

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -106,7 +106,13 @@ class ForNode : NodeType {
     } else if let range = resolved as? CountableRange<Int> {
       values = Array(range)
     } else {
-      values = []
+      let mirror = Mirror(reflecting: resolved)
+      switch mirror.displayStyle {
+      case .tuple?:
+        values = Array(mirror.children)
+      default:
+        values = []
+      }
     }
 
     if let `where` = self.where {

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -8,11 +8,18 @@ class ForNode : NodeType {
   let `where`: Expression?
 
   class func parse(_ parser:TokenParser, token:Token) throws -> NodeType {
-    let components = token.components()
+    var components = token.components()
+    
+    let error = TemplateSyntaxError("'for' statements should use the following 'for x in y where condition' `\(token.contents)`.")
+    guard components.count >= 3 else { throw error }
 
-    guard components.count >= 3 && components[2] == "in" &&
-        (components.count == 4 || (components.count >= 6 && components[4] == "where")) else {
-      throw TemplateSyntaxError("'for' statements should use the following 'for x in y where condition' `\(token.contents)`.")
+    // this will allow using comma with spaces between loop variables
+    if components[1].hasSuffix(",") {
+      components[1] = "\(components[1])\(components.remove(at: 2))"
+    }
+    
+    guard components[2] == "in" && (components.count == 4 || (components.count >= 6 && components[4] == "where")) else {
+      throw error
     }
 
     let loopVariables = components[1].characters

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -23,7 +23,18 @@ public protocol NodeType {
 
 /// Render the collection of nodes in the given context
 public func renderNodes(_ nodes:[NodeType], _ context:Context) throws -> String {
-  return try nodes.map { try $0.render(context) }.joined(separator: "")
+  var renderedNodes = ""
+  for node in nodes {
+    renderedNodes += try node.render(context)
+    
+    let shouldBreak = context[LoopTerminationNode.break.terminator] as? Bool ?? false
+    let shouldContinue = context[LoopTerminationNode.continue.terminator] as? Bool ?? false
+    
+    if shouldBreak || shouldContinue {
+      break
+    }
+  }
+  return renderedNodes
 }
 
 public class SimpleNode : NodeType {

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -18,6 +18,7 @@ public class TokenParser {
   public typealias TagParser = (TokenParser, Token) throws -> NodeType
 
   fileprivate var tokens: [Token]
+  fileprivate(set) var parsedTokens: [Token] = []
   fileprivate let environment: Environment
 
   public init(tokens: [Token], environment: Environment) {
@@ -61,7 +62,9 @@ public class TokenParser {
 
   public func nextToken() -> Token? {
     if tokens.count > 0 {
-      return tokens.remove(at: 0)
+      let nextToken = tokens.remove(at: 0)
+      parsedTokens.append(nextToken)
+      return nextToken
     }
 
     return nil
@@ -69,8 +72,11 @@ public class TokenParser {
 
   public func prependToken(_ token:Token) {
     tokens.insert(token, at: 0)
+    if parsedTokens.last == token {
+      parsedTokens.removeLast()
+    }
   }
-
+  
   func findTag(name: String) throws -> Extension.TagParser {
     for ext in environment.extensions {
       if let filter = ext.tags[name] {

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -78,6 +78,11 @@ public struct Variable : Equatable, Resolvable {
           current = dictionary.count
         } else {
           current = dictionary[bit]
+          if current == nil, let contextDict = context.dictionaries.last {
+            if let key = (try? Variable(bit).resolve(Context(dictionary: contextDict))) as? String {
+              current = dictionary[key]
+            }
+          }
         }
       } else if let array = current as? [Any] {
         if let index = Int(bit) {

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -78,10 +78,8 @@ public struct Variable : Equatable, Resolvable {
           current = dictionary.count
         } else {
           current = dictionary[bit]
-          if current == nil, let contextDict = context.dictionaries.last {
-            if let key = (try? Variable(bit).resolve(Context(dictionary: contextDict))) as? String {
-              current = dictionary[key]
-            }
+          if current == nil, let key = (try? Variable(bit).resolve(context)) as? String {
+            current = dictionary[key]
           }
         }
       } else if let array = current as? [Any] {
@@ -97,6 +95,12 @@ public struct Variable : Equatable, Resolvable {
           current = array.last
         } else if bit == "count" {
           current = array.count
+        } else if let index = (try? Variable(bit).resolve(context)) as? Int {
+          if index >= 0 && index < array.count {
+            current = array[index]
+          } else {
+            current = nil
+          }
         }
       } else if let object = current as? NSObject {  // NSKeyValueCoding
 #if os(Linux)
@@ -107,10 +111,8 @@ public struct Variable : Equatable, Resolvable {
       } else if let value = current {
         let mirror = Mirror(reflecting: value)
         current = mirror.getValue(for: bit)
-        if current == nil, let contextDict = context.dictionaries.last {
-          if let label = (try? Variable(bit).resolve(Context(dictionary: contextDict))) as? String {
-            current = mirror.getValue(for: label)
-          }
+        if current == nil, let label = (try? Variable(bit).resolve(context)) as? String {
+          current = mirror.getValue(for: label)
         }
         if current == nil {
           return nil

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -127,30 +127,45 @@ func testForNode() {
       try expect(result) == fixture
     }
 
-    $0.it("can iterate over dictionary") {
-      let templateString = "{% for key,value in dict %}" +
-        "{{ key }}: {{ value }}\n" +
-        "{% endfor %}\n"
-
+    $0.it("can iterate over array with index") {
+      let templateString = "{% for index, value in items %}" +
+        "{{ index }}: {{ value }}\n" +
+      "{% endfor %}\n"
+      
       let template = Template(templateString: templateString)
       let result = try template.render(context)
-
-      let fixture = "one: I\ntwo: II\n\n"
+      
+      let fixture = "0: 1\n1: 2\n2: 3\n\n"
       try expect(result) == fixture
     }
 
-    $0.it("renders supports iterating over dictionary") {
-      let nodes: [NodeType] = [VariableNode(variable: "key")]
-      let emptyNodes: [NodeType] = [TextNode(text: "empty")]
-      let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
-      try expect(try node.render(context)) == "onetwo"
-    }
 
-    $0.it("renders supports iterating over dictionary") {
-      let nodes: [NodeType] = [VariableNode(variable: "key"), VariableNode(variable: "value")]
-      let emptyNodes: [NodeType] = [TextNode(text: "empty")]
-      let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key", "value"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
-      try expect(try node.render(context)) == "oneItwoII"
+    $0.context("given dictionary") {
+      $0.it("can iterate over keys and values") {
+        let templateString = "{% for key, value in dict %}" +
+          "{{ key }}: {{ value }}\n" +
+        "{% endfor %}\n"
+        
+        let template = Template(templateString: templateString)
+        let result = try template.render(context)
+        
+        let fixture = "one: I\ntwo: II\n\n"
+        try expect(result) == fixture
+      }
+      
+      $0.it("renders supports iterating over dictionary") {
+        let nodes: [NodeType] = [VariableNode(variable: "key")]
+        let emptyNodes: [NodeType] = [TextNode(text: "empty")]
+        let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
+        try expect(try node.render(context)) == "onetwo"
+      }
+      
+      $0.it("renders supports iterating over dictionary") {
+        let nodes: [NodeType] = [VariableNode(variable: "key"), VariableNode(variable: "value")]
+        let emptyNodes: [NodeType] = [TextNode(text: "empty")]
+        let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key", "value"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
+        try expect(try node.render(context)) == "oneItwoII"
+      }
     }
 
     $0.it("handles invalid input") {

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -194,35 +194,43 @@ func testForNode() {
         
         let template = Template(templateString: templateString)
         let result = try template.render(context)
-        
-        let fixture = "one: I\ntwo: II\n\n"
-        try expect(result) == fixture
+
+        try expect(result.contains("one: I")).to.beTrue()
+        try expect(result.contains("two: II")).to.beTrue()
       }
       
       $0.it("can iterate over keys and subscript dictioanry") {
         let templateString = "{% for key in dict %}" +
           "{{ key }}: {{ dict.key }}\n" +
         "{% endfor %}\n"
-        
+
         let template = Template(templateString: templateString)
         let result = try template.render(context)
-        
-        let fixture = "one: I\ntwo: II\n\n"
-        try expect(result) == fixture
+
+        try expect(result.contains("one: I")).to.beTrue()
+        try expect(result.contains("two: II")).to.beTrue()
       }
       
       $0.it("renders supports iterating over dictionary") {
         let nodes: [NodeType] = [VariableNode(variable: "key")]
         let emptyNodes: [NodeType] = [TextNode(text: "empty")]
         let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
-        try expect(try node.render(context)) == "onetwo"
+
+        let result = try node.render(context)
+
+        try expect(result.contains("one")).to.beTrue()
+        try expect(result.contains("two")).to.beTrue()
       }
       
       $0.it("renders supports iterating over dictionary") {
         let nodes: [NodeType] = [VariableNode(variable: "key"), VariableNode(variable: "value")]
         let emptyNodes: [NodeType] = [TextNode(text: "empty")]
         let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key", "value"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
-        try expect(try node.render(context)) == "oneItwoII"
+
+        let result = try node.render(context)
+
+        try expect(result.contains("oneI")).to.beTrue()
+        try expect(result.contains("twoII")).to.beTrue()
       }
     }
 

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -139,6 +139,18 @@ func testForNode() {
       let fixture = "0: 1\n1: 2\n2: 3\n\n"
       try expect(result) == fixture
     }
+    
+    $0.it("can subscript array with index variable") {
+      let templateString = "{% for index, value in items %}" +
+        "{{ index }}: {{ items.index }}\n" +
+      "{% endfor %}\n"
+      
+      let template = Template(templateString: templateString)
+      let result = try template.render(context)
+      
+      let fixture = "0: 1\n1: 2\n2: 3\n\n"
+      try expect(result) == fixture
+    }
 
     $0.context("given tuple") {
       $0.it("can iterate over labels and values") {

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -153,6 +153,18 @@ func testForNode() {
         try expect(result) == fixture
       }
       
+      $0.it("can iterate over keys and subscript dictioanry") {
+        let templateString = "{% for key in dict %}" +
+          "{{ key }}: {{ dict.key }}\n" +
+        "{% endfor %}\n"
+        
+        let template = Template(templateString: templateString)
+        let result = try template.render(context)
+        
+        let fixture = "one: I\ntwo: II\n\n"
+        try expect(result) == fixture
+      }
+      
       $0.it("renders supports iterating over dictionary") {
         let nodes: [NodeType] = [VariableNode(variable: "key")]
         let emptyNodes: [NodeType] = [TextNode(text: "empty")]

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -11,7 +11,8 @@ func testForNode() {
       "dict": [
         "one": "I",
         "two": "II",
-      ]
+      ],
+      "tuple": (one: 1, two: 2)
     ])
 
     $0.it("renders the given nodes for each item") {
@@ -139,6 +140,51 @@ func testForNode() {
       try expect(result) == fixture
     }
 
+    $0.context("given tuple") {
+      $0.it("can iterate over labels and values") {
+        let templateString = "{% for label, value in tuple %}" +
+          "{{ label }}: {{ value }}\n" +
+        "{% endfor %}\n"
+        
+        let template = Template(templateString: templateString)
+        let result = try template.render(context)
+        
+        let fixture = "one: 1\ntwo: 2\n\n"
+        try expect(result) == fixture
+      }
+      
+      $0.it("can iterate over labels") {
+        let templateString = "{% for label in tuple %}" +
+          "{{ label }}: {{ tuple.label }}\n" +
+        "{% endfor %}\n"
+        
+        let template = Template(templateString: templateString)
+        let result = try template.render(context)
+        
+        let fixture = "one: 1\ntwo: 2\n\n"
+        try expect(result) == fixture
+      }
+      
+      $0.it("can subscript tuple by index") {
+        let templateString = "{{ tuple.0 }}{{ tuple.1 }}\n"
+        
+        let template = Template(templateString: templateString)
+        let result = try template.render(context)
+        
+        let fixture = "12\n"
+        try expect(result) == fixture
+      }
+      
+      $0.it("can subscript tuple by label") {
+        let templateString = "{{ tuple.one }}{{ tuple.two }}\n"
+        
+        let template = Template(templateString: templateString)
+        let result = try template.render(context)
+        
+        let fixture = "12\n"
+        try expect(result) == fixture
+      }
+    }
 
     $0.context("given dictionary") {
       $0.it("can iterate over keys and values") {


### PR DESCRIPTION
This PR contains several improvements for `for` tag:

- fixed using spaces between loop variables. Before it was failing parsing.

```
{% for key, value in dict %}
```

- added subscripting arrays and dictionaries using loop variable for index or key:

```
{% for index, value in array %}
{{ index }}: {{ array.index }}
{% endfor %}
```

```
{% for key in dict %}
{{ key }}: {{ dict.key }}
{% endfor %}
```

- added support for iterating arrays with index and value. This (almost) removes need for `forloop.counter` and `forloop.counter0` variables.

```
{% for index, value in array %}
{{ index }}: {{ value }}
{% endfor %}
```
- added support for iterating tuples, similar to iterating dictionaries:

```
{% for label, value in tuple %}
{{ label }}: {{ value }}
{% endfor %}
```

```
{% for label in tuple %}
{{ label }}: {{ tuple.label }}
{% endfor %}
```

- add support for subscripting tuples with labels and indexes. I.e. tuple `(one: 1, two: 2)` can be subscripted with labels: `{{ tuple.one }} {{ tuple.two }}` or with indexes: `{{ tuple.0 }} {{ tuple.1 }} `

- added `break` and `continue` tags for breaking/continuing current loop (I started to implement labeled loops, but it will require a bit more effort).

```
{% for item in items %}
  {{ item }}
  {% if condition %}{% break %}{% endif %}
{% endfor %}
```