### PR TITLE
fixed resolving variable as string literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed rendering `{{ block.super }}` with several levels of inheritance
 - Fixed checking dictionary values for nil in `default` filter
+- Fixed comparing string variables with string literals
 
 
 ## 0.10.1

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -60,7 +60,7 @@ public struct Variable : Equatable, Resolvable {
 
     if (variable.hasPrefix("'") && variable.hasSuffix("'")) || (variable.hasPrefix("\"") && variable.hasSuffix("\"")) {
       // String literal
-      return variable[variable.characters.index(after: variable.startIndex) ..< variable.characters.index(before: variable.endIndex)]
+      return String(variable[variable.characters.index(after: variable.startIndex) ..< variable.characters.index(before: variable.endIndex)])
     }
 
     if let number = Number(variable) {


### PR DESCRIPTION
Resolves #159

For some reason in unit tests `Variable.resolve` method returns `String` in this case
but in the app on iOS simulator it results in Swift.Substring (which is actually expected)
and then check for String type in EqualityExpression fails.