### PR TITLE
Fixed using spaces between loop variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed rendering `{{ block.super }}` with several levels of inheritance
 - Fixed checking dictionary values for nil in `default` filter
+- Fixed using spaces between loop variables
 
 
 ## 0.10.1

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -4,7 +4,7 @@ public class Context {
 
   public let environment: Environment
 
-  init(dictionary: [String: Any]? = nil, environment: Environment? = nil) {
+  init(dictionary: [String: Any?]? = nil, environment: Environment? = nil) {
     if let dictionary = dictionary {
       dictionaries = [dictionary]
     } else {
@@ -37,7 +37,7 @@ public class Context {
   }
 
   /// Push a new level into the Context
-  fileprivate func push(_ dictionary: [String: Any]? = nil) {
+  fileprivate func push(_ dictionary: [String: Any?]? = nil) {
     dictionaries.append(dictionary ?? [:])
   }
 
@@ -47,14 +47,14 @@ public class Context {
   }
 
   /// Push a new level onto the context for the duration of the execution of the given closure
-  public func push<Result>(dictionary: [String: Any]? = nil, closure: (() throws -> Result)) rethrows -> Result {
+  public func push<Result>(dictionary: [String: Any?]? = nil, closure: (() throws -> Result)) rethrows -> Result {
     push(dictionary)
     defer { _ = pop() }
     return try closure()
   }
 
-  public func flatten() -> [String: Any] {
-    var accumulator: [String: Any] = [:]
+  public func flatten() -> [String: Any?] {
+    var accumulator: [String: Any?] = [:]
 
     for dictionary in dictionaries {
       for (key, value) in dictionary {

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -8,11 +8,18 @@ class ForNode : NodeType {
   let `where`: Expression?
 
   class func parse(_ parser:TokenParser, token:Token) throws -> NodeType {
-    let components = token.components()
+    var components = token.components()
+    
+    let error = TemplateSyntaxError("'for' statements should use the following 'for x in y where condition' `\(token.contents)`.")
+    guard components.count >= 3 else { throw error }
 
-    guard components.count >= 3 && components[2] == "in" &&
-        (components.count == 4 || (components.count >= 6 && components[4] == "where")) else {
-      throw TemplateSyntaxError("'for' statements should use the following 'for x in y where condition' `\(token.contents)`.")
+    // this will allow using comma with spaces between loop variables
+    if components[1].hasSuffix(",") {
+      components[1] = "\(components[1])\(components.remove(at: 2))"
+    }
+    
+    guard components[2] == "in" && (components.count == 4 || (components.count >= 6 && components[4] == "where")) else {
+      throw error
     }
 
     let loopVariables = components[1].characters

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -128,7 +128,7 @@ func testForNode() {
     }
 
     $0.it("can iterate over dictionary") {
-      let templateString = "{% for key,value in dict %}" +
+      let templateString = "{% for key, value in dict %}" +
         "{{ key }}: {{ value }}\n" +
         "{% endfor %}\n"
 

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -135,22 +135,28 @@ func testForNode() {
       let template = Template(templateString: templateString)
       let result = try template.render(context)
 
-      let fixture = "one: I\ntwo: II\n\n"
-      try expect(result) == fixture
+      try expect(result.contains("one: I")).to.beTrue()
+      try expect(result.contains("two: II")).to.beTrue()
     }
 
     $0.it("renders supports iterating over dictionary") {
       let nodes: [NodeType] = [VariableNode(variable: "key")]
       let emptyNodes: [NodeType] = [TextNode(text: "empty")]
       let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
-      try expect(try node.render(context)) == "onetwo"
+      
+      let result = try node.render(context)
+      try expect(result.contains("one")).to.beTrue()
+      try expect(result.contains("two")).to.beTrue()
     }
 
     $0.it("renders supports iterating over dictionary") {
       let nodes: [NodeType] = [VariableNode(variable: "key"), VariableNode(variable: "value")]
       let emptyNodes: [NodeType] = [TextNode(text: "empty")]
       let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key", "value"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
-      try expect(try node.render(context)) == "oneItwoII"
+      
+      let result = try node.render(context)
+      try expect(result.contains("oneI")).to.beTrue()
+      try expect(result.contains("twoII")).to.beTrue()
     }
 
     $0.it("handles invalid input") {


### PR DESCRIPTION
Though docs [say](https://stencil.fuller.li/en/latest/builtins.html#built-in-tags) that you can do `for key, value in dict` in fact it was failing parsing.