### PR TITLE
Iterating arrays with their indexes and values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added support for iterating arrays of tuples
 - Added support for ranges in if-in expression
 - Added property `forloop.length` to get number of items in the loop
+- Now you can iterate arrays using their indexes and values, not just values
 
 ### Bug Fixes
 

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -90,7 +90,11 @@ class ForNode : NodeType {
     if let dictionary = resolved as? [String: Any], !dictionary.isEmpty {
       values = dictionary.map { ($0.key, $0.value) }
     } else if let array = resolved as? [Any] {
-      values = array
+      if loopVariables.count == 2 {
+        values = array.enumerated().map({ ($0.offset, $0.element) })
+      } else {
+        values = array
+      }
     } else if let range = resolved as? CountableClosedRange<Int> {
       values = Array(range)
     } else if let range = resolved as? CountableRange<Int> {

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -178,7 +178,18 @@ func testForNode() {
         let template = Template(templateString: templateString)
         try expect(template.render(context)).toThrow()
       }
+    }
 
+    $0.it("can iterate over array with index") {
+      let templateString = "{% for index,value in items %}" +
+        "{{ index }}: {{ value }}\n" +
+      "{% endfor %}\n"
+
+      let template = Template(templateString: templateString)
+      let result = try template.render(context)
+
+      let fixture = "0: 1\n1: 2\n2: 3\n\n"
+      try expect(result) == fixture
     }
 
     $0.it("can iterate over dictionary") {


### PR DESCRIPTION
This allows to enumerate arrays by their indexes and values, not just by their values, instead of using `forloop` context variable.