### PR TITLE
Fixed tuple subscript by value index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Integer literals now resolve into Int values, not Float
 - Fixed accessing properties of optional properties via reflection
 - No longer render optional values in arrays as `Optional(..)`
+- Fixed subscription tuples by value index, i.e. `{{ tuple.0 }}`
 
 
 ## 0.10.1

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -183,7 +183,7 @@ func parseFilterComponents(token: String) -> (String, [Variable]) {
 
 extension Mirror {
   func getValue(for key: String) -> Any? {
-    let result = descendant(key)
+    let result = descendant(key) ?? Int(key).flatMap({ descendant($0) })
     if result == nil {
       // go through inheritance chain to reach superclass properties
       return superclassMirror?.getValue(for: key)

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -40,7 +40,8 @@ func testVariable() {
       "counter": [
         "count": "kylef",
         ],
-      "article": Article(author: Person(name: "Kyle"))
+      "article": Article(author: Person(name: "Kyle")),
+      "tuple": (one: 1, two: 2)
     ])
 
 #if os(OSX)
@@ -174,6 +175,18 @@ func testVariable() {
 
       try expect(VariableNode(variable: "values").render(context)) == "[1, nil, [1, nil]]"
       try expect(VariableNode(variable: "values.1").render(context)) == ""
+    }
+
+    $0.it("can subscript tuple by index") {
+      let variable = Variable("tuple.0")
+      let result = try variable.resolve(context) as? Int
+      try expect(result) == 1
+    }
+
+    $0.it("can subscript tuple by label") {
+      let variable = Variable("tuple.two")
+      let result = try variable.resolve(context) as? Int
+      try expect(result) == 2
     }
   }
 }


### PR DESCRIPTION
This PR fixes subscripting tuples by index of their value, i.e. `{{ tuple.0 }}`