### PR TITLE
Iterating properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Added support for resolving superclass properties for not-NSObject subclasses
+- You can now iterate objects and values of structs and tuples over their stored properties by their names and values  
 
 ### Bug Fixes
 

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -4,7 +4,7 @@ public class Context {
 
   public let environment: Environment
 
-  init(dictionary: [String: Any]? = nil, environment: Environment? = nil) {
+  init(dictionary: [String: Any?]? = nil, environment: Environment? = nil) {
     if let dictionary = dictionary {
       dictionaries = [dictionary]
     } else {
@@ -37,7 +37,7 @@ public class Context {
   }
 
   /// Push a new level into the Context
-  fileprivate func push(_ dictionary: [String: Any]? = nil) {
+  fileprivate func push(_ dictionary: [String: Any?]? = nil) {
     dictionaries.append(dictionary ?? [:])
   }
 
@@ -47,14 +47,14 @@ public class Context {
   }
 
   /// Push a new level onto the context for the duration of the execution of the given closure
-  public func push<Result>(dictionary: [String: Any]? = nil, closure: (() throws -> Result)) rethrows -> Result {
+  public func push<Result>(dictionary: [String: Any?]? = nil, closure: (() throws -> Result)) rethrows -> Result {
     push(dictionary)
     defer { _ = pop() }
     return try closure()
   }
 
-  public func flatten() -> [String: Any] {
-    var accumulator: [String: Any] = [:]
+  public func flatten() -> [String: Any?] {
+    var accumulator: [String: Any?] = [:]
 
     for dictionary in dictionaries {
       for (key, value) in dictionary {

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -94,6 +94,22 @@ class ForNode : NodeType {
       values = Array(range)
     } else if let range = resolved as? CountableRange<Int> {
       values = Array(range)
+    } else if let resolved = resolved {
+      let mirror = Mirror(reflecting: resolved)
+      switch mirror.displayStyle {
+      case .struct?, .tuple?:
+        values = Array(mirror.children)
+      case .class?:
+        var children = Array(mirror.children)
+        var currentMirror: Mirror? = mirror
+        while let superclassMirror = currentMirror?.superclassMirror {
+          children.append(contentsOf: superclassMirror.children)
+          currentMirror = superclassMirror
+        }
+        values = Array(children)
+      default:
+        values = []
+      }
     } else {
       values = []
     }

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -167,7 +167,61 @@ func testForNode() {
       let error = TemplateSyntaxError("'for' statements should use the following 'for x in y where condition' `for i`.")
       try expect(try parser.parse()).toThrow(error)
     }
+
+    $0.it("iterates struct properties") {
+      struct MyStruct {
+        let string: String
+        let number: Int
+      }
+
+      let context = Context(dictionary: [
+        "struct": MyStruct(string: "abc", number: 123)
+        ])
+
+      let nodes: [NodeType] = [VariableNode(variable: "property"), VariableNode(variable: "\":\""), VariableNode(variable: "value"),VariableNode(variable: "\";\"")]
+      let node = ForNode(resolvable: Variable("struct"), loopVariables: ["property", "value"], nodes: nodes, emptyNodes: [])
+      try expect(try node.render(context)) == "string:abc;number:123;"
+    }
+
+    $0.it("iterates tuple items") {
+      let context = Context(dictionary: [
+        "tuple": (one: 1, two: "dva"),
+        ])
+
+      let nodes: [NodeType] = [VariableNode(variable: "label"), VariableNode(variable: "\":\""), VariableNode(variable: "value"),VariableNode(variable: "\";\"")]
+      let node = ForNode(resolvable: Variable("tuple"), loopVariables: ["label", "value"], nodes: nodes, emptyNodes: [])
+      try expect(try node.render(context)) == "one:1;two:dva;"
+    }
+
+    $0.it("iterates class properties") {
+      class MyClass {
+        var baseString: String
+        var baseInt: Int
+        init(_ string: String, _ int: Int) {
+          baseString = string
+          baseInt = int
+        }
+      }
+
+      class MySubclass: MyClass {
+        var childString: String
+        init(_ childString: String, _ string: String, _ int: Int) {
+          self.childString = childString
+          super.init(string, int)
+        }
+      }
+
+      let context = Context(dictionary: [
+        "class": MySubclass("child", "base", 1)
+        ])
+
+      let nodes: [NodeType] = [VariableNode(variable: "label"), VariableNode(variable: "\":\""), VariableNode(variable: "value"),VariableNode(variable: "\";\"")]
+      let node = ForNode(resolvable: Variable("class"), loopVariables: ["label", "value"], nodes: nodes, emptyNodes: [])
+      try expect(try node.render(context)) == "childString:child;baseString:base;baseInt:1;"
+    }
+
   }
+
 }
 
 

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -135,22 +135,28 @@ func testForNode() {
       let template = Template(templateString: templateString)
       let result = try template.render(context)
 
-      let fixture = "one: I\ntwo: II\n\n"
-      try expect(result) == fixture
+      try expect(result.contains("one: I")).to.beTrue()
+      try expect(result.contains("two: II")).to.beTrue()
     }
 
     $0.it("renders supports iterating over dictionary") {
       let nodes: [NodeType] = [VariableNode(variable: "key")]
       let emptyNodes: [NodeType] = [TextNode(text: "empty")]
       let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
-      try expect(try node.render(context)) == "onetwo"
+      
+      let result = try node.render(context)
+      try expect(result.contains("one")).to.beTrue()
+      try expect(result.contains("two")).to.beTrue()
     }
 
     $0.it("renders supports iterating over dictionary") {
       let nodes: [NodeType] = [VariableNode(variable: "key"), VariableNode(variable: "value")]
       let emptyNodes: [NodeType] = [TextNode(text: "empty")]
       let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key", "value"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
-      try expect(try node.render(context)) == "oneItwoII"
+      
+      let result = try node.render(context)
+      try expect(result.contains("oneI")).to.beTrue()
+      try expect(result.contains("twoII")).to.beTrue()
     }
 
     $0.it("handles invalid input") {


### PR DESCRIPTION
This PR adds support for iterating objects, structs and tuples over their properties. One use case I can think of for this is to avoid converting native types to json to print out their propertis in a generic way. Not sure how else this can be useful though =)