### PR TITLE
Using variables for subscripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added support for resolving superclass properties for not-NSObject subclasses
 - The `{% for %}` tag can now iterate over tuples, structures and classes via
   their stored properties.
+- Now you can use variables to subscript other values, i.e. `{{ dict.key }}` will first lookup "key" in dictionary,
+  but if there is no value for such key it will try to resolve `key` variable and subscript dictionary with its value  
 
 ### Bug Fixes
 

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -81,6 +81,9 @@ public struct Variable : Equatable, Resolvable {
           current = dictionary.count
         } else {
           current = dictionary[bit]
+          if current == nil, let key = context[bit] as? String {
+            current = dictionary[key]
+          }
         }
       } else if let array = current as? [Any] {
         if let index = Int(bit) {
@@ -95,17 +98,27 @@ public struct Variable : Equatable, Resolvable {
           current = array.last
         } else if bit == "count" {
           current = array.count
+        } else if let index = context[bit] as? Int {
+          if index >= 0 && index < array.count {
+            current = array[index]
+          } else {
+            current = nil
+          }
         }
       } else if let object = current as? NSObject {  // NSKeyValueCoding
 #if os(Linux)
         return nil
 #else
         current = object.value(forKey: bit)
+        if current == nil, let key = context[bit] as? String {
+          current = object.value(forKey: key)
+        }
 #endif
       } else if let value = current {
-        current = Mirror(reflecting: value).getValue(for: bit)
-        if current == nil {
-          return nil
+        let mirror = Mirror(reflecting: value)
+        current = mirror.getValue(for: bit)
+        if current == nil, let label = context[bit] as? String {
+          current = mirror.getValue(for: label)
         }
       } else {
         return nil

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -7,11 +7,13 @@ func testForNode() {
   describe("ForNode") {
     let context = Context(dictionary: [
       "items": [1, 2, 3],
+      "indices": [0, 1, 2],
       "emptyItems": [Int](),
       "dict": [
         "one": "I",
         "two": "II",
-      ]
+      ],
+      "keys": ["one", "two"]
     ])
 
     $0.it("renders the given nodes for each item") {
@@ -124,6 +126,43 @@ func testForNode() {
         "- Memory Management with ARC by Kyle Fuller.\n" +
         "\n"
 
+      try expect(result) == fixture
+    }
+
+    $0.it("can subscript array with index variable") {
+      let templateString = "{% for index in indices %}" +
+        "{{ index }}: {{ items.index }}\n" +
+      "{% endfor %}\n"
+
+      let template = Template(templateString: templateString)
+      let result = try template.render(context)
+
+      let fixture = "0: 1\n1: 2\n2: 3\n\n"
+      try expect(result) == fixture
+    }
+
+    $0.it("can subscript dictionary with key variable") {
+      let templateString = "{% for key in keys %}" +
+        "{{ key }}: {{ dict.key }}\n" +
+      "{% endfor %}\n"
+
+      let template = Template(templateString: templateString)
+      let result = try template.render(context)
+
+      let fixture = "one: I\ntwo: II\n\n"
+      try expect(result) == fixture
+    }
+
+    $0.it("does not subscript dictionary with key variable if value is set but nil") {
+      let templateString = "{% for key in keys %}" +
+        "{{ key }}: {{ dict.key }}\n" +
+      "{% endfor %}\n"
+
+      let template = Template(templateString: templateString)
+      let nilValue: String? = nil
+      let result = try template.render(Context(dictionary: ["dict": ["key": nilValue], "keys": ["one", "two"]]))
+
+      let fixture = "one: \ntwo: \n\n"
       try expect(result) == fixture
     }
 


### PR DESCRIPTION
This PR allows to use variables values for subscripting properties of another variables, i.e. given context `["keys": ["one", "two", "three"], "dict": ["one": "I", "two": "II", "three": "III"]]` following template will print "I II III".

```
{% for key in keys %}
{{ dict.key }} 
{% endfor %}
```
The same applies for index dictionaries and properties
This can be useful for ordered dictionary iteration and adds more dynamism to the templates.