### PR TITLE
Range variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for resolving superclass properties for not-NSObject subclasses
 - The `{% for %}` tag can now iterate over tuples, structures and classes via
   their stored properties.
+- Now you can construct ranges for loops using `a to b` syntax, i.e. `for i in 1 to array.count`
 
 ### Bug Fixes
 

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -144,12 +144,12 @@ public struct RangeVariable: Resolvable {
     guard let to = toResolved.flatMap(toNumber(value:)).flatMap(Int.init) else {
       throw TemplateSyntaxError("to value \(toResolved ?? "nil") is not an int")
     }
-
-    guard from < to else {
-      throw TemplateSyntaxError("from value (\(from)) is not less than to value (\(to))")
+    let range = min(from, to)...max(from, to)
+    if from > to {
+      return Array(range.reversed())
+    } else {
+      return Array(range)
     }
-
-    return CountableClosedRange<Int>(uncheckedBounds: (lower: from, upper: to))
   }
 
 }

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -126,6 +126,34 @@ public func ==(lhs: Variable, rhs: Variable) -> Bool {
   return lhs.variable == rhs.variable
 }
 
+/// A structure used to represet range of to integer values expressed as `from to to`.
+/// Values should be numbers (they will be converted to integers) and `from` should be less than `to`.
+/// Rendering this variable produces closed range `from...to`
+public struct RangeVariable: Resolvable {
+  public let from: Resolvable
+  public let to: Resolvable
+
+  public func resolve(_ context: Context) throws -> Any? {
+    let fromResolved = try from.resolve(context)
+    let toResolved = try to.resolve(context)
+
+    guard let from = fromResolved.flatMap(toNumber(value:)).flatMap(Int.init) else {
+      throw TemplateSyntaxError("from value \(fromResolved ?? "nil") is not an int")
+    }
+
+    guard let to = toResolved.flatMap(toNumber(value:)).flatMap(Int.init) else {
+      throw TemplateSyntaxError("to value \(toResolved ?? "nil") is not an int")
+    }
+
+    guard from < to else {
+      throw TemplateSyntaxError("from value (\(from)) is not less than to value (\(to))")
+    }
+
+    return CountableClosedRange<Int>(uncheckedBounds: (lower: from, upper: to))
+  }
+
+}
+
 
 func normalize(_ current: Any?) -> Any? {
   if let current = current as? Normalizable {

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -90,9 +90,9 @@ func testForNode() {
         try expect(try template.render(Context(dictionary: ["j": "3", "k": 1]))).toThrow()
       }
 
-      $0.it("throws if right value is not more than left value") {
+      $0.it("can use decreasing range") {
         let template: Template = "{% for i in k to j %}{{ i }}{% endfor %}"
-        try expect(try template.render(Context(dictionary: ["k": 3, "j": 1]))).toThrow()
+        try expect(try template.render(Context(dictionary: ["k": 3, "j": 1]))) == "321"
       }
 
       $0.it("throws is left range value is missing") {


### PR DESCRIPTION
This PR introduces new syntax for `for` loops - `{% for i in a to b %}`. `a to b` will produce a range variable which will render itself as closed range `a...b`. Values can be number literals or context variables, they will be resolved while rendering range variable.