### PR TITLE
Fix creating float from int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed rendering `{{ block.super }}` with several levels of inheritance
 - Fixed checking dictionary values for nil in `default` filter
 - Fixed comparing string variables with string literals, in Swift 4 string literals became `Substring` and thus couldn't be directly compared to strings.
+- Integer literals now resolve into Int values, not Float
 
 
 ## 0.10.1

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -63,8 +63,11 @@ public struct Variable : Equatable, Resolvable {
       return String(variable[variable.characters.index(after: variable.startIndex) ..< variable.characters.index(before: variable.endIndex)])
     }
 
+    // Number literal
+    if let int = Int(variable) {
+      return int
+    }
     if let number = Number(variable) {
-      // Number literal
       return number
     }
 

--- a/Tests/StencilTests/FilterSpec.swift
+++ b/Tests/StencilTests/FilterSpec.swift
@@ -136,7 +136,19 @@ func testFilter() {
       let result = try template.render(Context(dictionary: [:]))
       try expect(result) == "Hello World"
     }
-    
+
+    $0.it("can use int as default") {
+      let template = Template(templateString: "{{ value|default:1 }}")
+      let result = try template.render(Context(dictionary: [:]))
+      try expect(result) == "1"
+    }
+
+    $0.it("can use float as default") {
+      let template = Template(templateString: "{{ value|default:1.5 }}")
+      let result = try template.render(Context(dictionary: [:]))
+      try expect(result) == "1.5"
+    }
+
     $0.it("checks for underlying nil value correctly") {
       let template = Template(templateString: "Hello {{ user.name|default:\"anonymous\" }}")
       let nilName: String? = nil

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -129,13 +129,13 @@ func testForNode() {
 
     $0.it("can iterate over dictionary") {
       let templateString = "{% for key,value in dict %}" +
-        "{{ key }}: {{ value }}\n" +
-        "{% endfor %}\n"
+        "{{ key }}: {{ value }}," +
+        "{% endfor %}"
 
       let template = Template(templateString: templateString)
       let result = try template.render(context)
 
-      let sortedResult = result.split(separator: "\n").sorted(by: <)
+      let sortedResult = result.characters.split(separator: ",").map(String.init).sorted(by: <)
       try expect(sortedResult) == ["one: I", "two: II"]
     }
 
@@ -148,7 +148,7 @@ func testForNode() {
       let node = ForNode(resolvable: Variable("dict"), loopVariables: ["key"], nodes: nodes, emptyNodes: emptyNodes, where: nil)
       let result = try node.render(context)
 
-      let sortedResult = result.split(separator: ",").sorted(by: <)
+      let sortedResult = result.characters.split(separator: ",").map(String.init).sorted(by: <)
       try expect(sortedResult) == ["one", "two"]
     }
 
@@ -164,7 +164,7 @@ func testForNode() {
 
       let result = try node.render(context)
 
-      let sortedResult = result.split(separator: ",").sorted(by: <)
+      let sortedResult = result.characters.split(separator: ",").map(String.init).sorted(by: <)
       try expect(sortedResult) == ["one=I", "two=II"]
     }
 

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -61,7 +61,7 @@ func testVariable() {
 
     $0.it("can resolve an integer literal") {
       let variable = Variable("5")
-      let result = try variable.resolve(context) as? Number
+      let result = try variable.resolve(context) as? Int
       try expect(result) == 5
     }
 


### PR DESCRIPTION
Currently all number literals are implicitly converted to Float, which can lead to unexpected output, i.e.
`"{{ value|default:0 }}"` will output `0.0` where `0` is more likely expected. This fix first checks if literal is an Int and then returns it, otherwise it returns Float.