### PR TITLE
Added indent filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for resolving superclass properties for not-NSObject subclasses
 - The `{% for %}` tag can now iterate over tuples, structures and classes via
   their stored properties.
+- Added `indent` filter
 
 ### Bug Fixes
 

--- a/Sources/Extension.swift
+++ b/Sources/Extension.swift
@@ -57,6 +57,7 @@ class DefaultExtension: Extension {
     registerFilter("uppercase", filter: uppercase)
     registerFilter("lowercase", filter: lowercase)
     registerFilter("join", filter: joinFilter)
+    registerFilter("indent", filter: indentFilter)
   }
 }
 

--- a/Sources/Filters.swift
+++ b/Sources/Filters.swift
@@ -26,7 +26,7 @@ func defaultFilter(value: Any?, arguments: [Any?]) -> Any? {
 }
 
 func joinFilter(value: Any?, arguments: [Any?]) throws -> Any? {
-  guard arguments.count <= 1 else {
+  guard arguments.count < 2 else {
     throw TemplateSyntaxError("'join' filter takes a single argument")
   }
 
@@ -42,21 +42,22 @@ func joinFilter(value: Any?, arguments: [Any?]) throws -> Any? {
 }
 
 func indentFilter(value: Any?, arguments: [Any?]) throws -> Any? {
-  guard !arguments.isEmpty else {
-    throw TemplateSyntaxError("'indent' filter takes at least 1 argument")
-  }
   guard arguments.count <= 3 else {
     throw TemplateSyntaxError("'indent' filter can take at most 3 arguments")
   }
 
-  guard let indentWidth = arguments[0] as? Int else {
-    throw TemplateSyntaxError("first argument should be Int")
+  var indentWidth = 4
+  if arguments.count > 0 {
+    guard let value = arguments[0] as? Int else {
+      throw TemplateSyntaxError("'indent' filter width argument must be an Integer (\(String(describing: arguments[0])))")
+    }
+    indentWidth = value
   }
 
   var indentationChar = " "
   if arguments.count > 1 {
     guard let value = arguments[1] as? String else {
-      throw TemplateSyntaxError("second argument should be String")
+      throw TemplateSyntaxError("'indent' filter indentation argument must be a String (\(String(describing: arguments[1]))")
     }
     indentationChar = value
   }
@@ -64,7 +65,7 @@ func indentFilter(value: Any?, arguments: [Any?]) throws -> Any? {
   var indentFirst = false
   if arguments.count > 2 {
     guard let value = arguments[2] as? Bool else {
-      throw TemplateSyntaxError("third argument should be Bool")
+      throw TemplateSyntaxError("'indent' filter indentFirst argument must be a Bool")
     }
     indentFirst = value
   }

--- a/Sources/Filters.swift
+++ b/Sources/Filters.swift
@@ -26,7 +26,7 @@ func defaultFilter(value: Any?, arguments: [Any?]) -> Any? {
 }
 
 func joinFilter(value: Any?, arguments: [Any?]) throws -> Any? {
-  guard arguments.count < 2 else {
+  guard arguments.count <= 1 else {
     throw TemplateSyntaxError("'join' filter takes a single argument")
   }
 
@@ -40,3 +40,48 @@ func joinFilter(value: Any?, arguments: [Any?]) throws -> Any? {
 
   return value
 }
+
+func indentFilter(value: Any?, arguments: [Any?]) throws -> Any? {
+  guard !arguments.isEmpty else {
+    throw TemplateSyntaxError("'indent' filter takes at least 1 argument")
+  }
+  guard arguments.count <= 3 else {
+    throw TemplateSyntaxError("'indent' filter can take at most 3 arguments")
+  }
+
+  guard let indentWidth = arguments[0] as? Int else {
+    throw TemplateSyntaxError("first argument should be Int")
+  }
+
+  var indentationChar = " "
+  if arguments.count > 1 {
+    guard let value = arguments[1] as? String else {
+      throw TemplateSyntaxError("second argument should be String")
+    }
+    indentationChar = value
+  }
+
+  var indentFirst = false
+  if arguments.count > 2 {
+    guard let value = arguments[2] as? Bool else {
+      throw TemplateSyntaxError("third argument should be Bool")
+    }
+    indentFirst = value
+  }
+
+  let indentation = [String](repeating: indentationChar, count: indentWidth).joined(separator: "")
+  return indent(stringify(value), indentation: indentation, indentFirst: indentFirst)
+}
+
+
+func indent(_ content: String, indentation: String, indentFirst: Bool) -> String {
+  guard !indentation.isEmpty else { return content }
+
+  var lines = content.components(separatedBy: .newlines)
+  let firstLine = (indentFirst ? indentation : "") + lines.removeFirst()
+  let result = lines.reduce([firstLine]) { (result, line) in
+    return result + [(line.isEmpty ? "" : "\(indentation)\(line)")]
+  }
+  return result.joined(separator: "\n")
+}
+

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -70,6 +70,10 @@ public struct Variable : Equatable, Resolvable {
     if let number = Number(variable) {
       return number
     }
+    // Boolean literal
+    if let bool = Bool(variable) {
+      return bool
+    }
 
     for bit in lookup() {
       current = normalize(current)

--- a/Tests/StencilTests/FilterSpec.swift
+++ b/Tests/StencilTests/FilterSpec.swift
@@ -202,5 +202,11 @@ func testFilter() {
       let result = try template.render(Context(dictionary: ["value": "One\nTwo"]))
       try expect(result) == "  One\n  Two"
     }
+
+    $0.it("does not indent empty lines") {
+      let template = Template(templateString: "{{ value|indent }}")
+      let result = try template.render(Context(dictionary: ["value": "One\n\n\nTwo\n\n"]))
+      try expect(result) == "One\n\n\n    Two\n\n"
+    }
   }
 }

--- a/Tests/StencilTests/FilterSpec.swift
+++ b/Tests/StencilTests/FilterSpec.swift
@@ -183,4 +183,24 @@ func testFilter() {
       try expect(result) == "OneTwo"
     }
   }
+
+  describe("indent filter") {
+    $0.it("indents content") {
+      let template = Template(templateString: "{{ value|indent:2 }}")
+      let result = try template.render(Context(dictionary: ["value": "One\nTwo"]))
+      try expect(result) == "One\n  Two"
+    }
+
+    $0.it("can indent with arbitrary character") {
+      let template = Template(templateString: "{{ value|indent:2,\"\t\" }}")
+      let result = try template.render(Context(dictionary: ["value": "One\nTwo"]))
+      try expect(result) == "One\n\t\tTwo"
+    }
+
+    $0.it("can indent first line") {
+      let template = Template(templateString: "{{ value|indent:2,\" \",true }}")
+      let result = try template.render(Context(dictionary: ["value": "One\nTwo"]))
+      try expect(result) == "  One\n  Two"
+    }
+  }
 }

--- a/Tests/StencilTests/FilterTagSpec.swift
+++ b/Tests/StencilTests/FilterTagSpec.swift
@@ -21,5 +21,14 @@ func testFilterTag() {
       try expect(try template.render()).toThrow()
     }
 
+    $0.it("can render filters with arguments") {
+      let ext = Extension()
+      ext.registerFilter("split", filter: {
+        return ($0 as! String).components(separatedBy: $1[0] as! String)
+      })
+      let env = Environment(extensions: [ext])
+      let result = try env.renderTemplate(string: "{% filter split:\",\"|join:\";\"  %}{{ items|join:\",\" }}{% endfilter %}", context: ["items": [1, 2]])
+      try expect(result) == "1;2"
+    }
   }
 }

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -71,6 +71,13 @@ func testVariable() {
       try expect(result) == 3.14
     }
 
+    $0.it("can resolve boolean literal") {
+      try expect(Variable("true").resolve(context) as? Bool) == true
+      try expect(Variable("false").resolve(context) as? Bool) == false
+      try expect(Variable("0").resolve(context) as? Int) == 0
+      try expect(Variable("1").resolve(context) as? Int) == 1
+    }
+
     $0.it("can resolve a string variable") {
       let variable = Variable("name")
       let result = try variable.resolve(context) as? String


### PR DESCRIPTION
With this filter it is possible to indent content either of variable or included from another template.

Examples:

```
Indented text: {{ "first line\nsecond line"|indent:2,"\t"}}
```

will render:

```
Indented text: first line
\t\tsecond line
```

With `filter` tag indentation can be also applied to included template content:

```
Included text: {% filter indent:2 %}{% include "text.html" %}{% endfilter %}
```

will render:

```
Included text: first line
  second line
```

Resolves #95 