### PR TITLE
Apply string filters to arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The `{% for %}` tag can now iterate over tuples, structures and classes via
   their stored properties.
 - Added `split` filter
+- Allow default string filters to be applied to arrays
 
 ### Bug Fixes
 

--- a/Sources/Filters.swift
+++ b/Sources/Filters.swift
@@ -1,13 +1,25 @@
 func capitalise(_ value: Any?) -> Any? {
-  return stringify(value).capitalized
+  if let array = value as? [Any?] {
+    return array.map { stringify($0).capitalized }
+  } else {
+    return stringify(value).capitalized
+  }
 }
 
 func uppercase(_ value: Any?) -> Any? {
-  return stringify(value).uppercased()
+  if let array = value as? [Any?] {
+    return array.map { stringify($0).uppercased() }
+  } else {
+    return stringify(value).uppercased()
+  }
 }
 
 func lowercase(_ value: Any?) -> Any? {
-  return stringify(value).lowercased()
+  if let array = value as? [Any?] {
+    return array.map { stringify($0).lowercased() }
+  } else {
+    return stringify(value).lowercased()
+  }
 }
 
 func defaultFilter(value: Any?, arguments: [Any?]) -> Any? {

--- a/Tests/StencilTests/FilterSpec.swift
+++ b/Tests/StencilTests/FilterSpec.swift
@@ -89,32 +89,45 @@ func testFilter() {
     }
   }
 
+  describe("string filters") {
+    $0.context("given string") {
+      $0.it("transforms a string to be capitalized") {
+        let template = Template(templateString: "{{ name|capitalize }}")
+        let result = try template.render(Context(dictionary: ["name": "kyle"]))
+        try expect(result) == "Kyle"
+      }
 
-  describe("capitalize filter") {
-    let template = Template(templateString: "{{ name|capitalize }}")
+      $0.it("transforms a string to be uppercase") {
+        let template = Template(templateString: "{{ name|uppercase }}")
+        let result = try template.render(Context(dictionary: ["name": "kyle"]))
+        try expect(result) == "KYLE"
+      }
 
-    $0.it("capitalizes a string") {
-      let result = try template.render(Context(dictionary: ["name": "kyle"]))
-      try expect(result) == "Kyle"
+      $0.it("transforms a string to be lowercase") {
+        let template = Template(templateString: "{{ name|lowercase }}")
+        let result = try template.render(Context(dictionary: ["name": "Kyle"]))
+        try expect(result) == "kyle"
+      }
     }
-  }
 
+    $0.context("given array of strings") {
+      $0.it("transforms a string to be capitalized") {
+        let template = Template(templateString: "{{ names|capitalize }}")
+        let result = try template.render(Context(dictionary: ["names": ["kyle", "kyle"]]))
+        try expect(result) == "[\"Kyle\", \"Kyle\"]"
+      }
 
-  describe("uppercase filter") {
-    let template = Template(templateString: "{{ name|uppercase }}")
+      $0.it("transforms a string to be uppercase") {
+        let template = Template(templateString: "{{ names|uppercase }}")
+        let result = try template.render(Context(dictionary: ["names": ["kyle", "kyle"]]))
+        try expect(result) == "[\"KYLE\", \"KYLE\"]"
+      }
 
-    $0.it("transforms a string to be uppercase") {
-      let result = try template.render(Context(dictionary: ["name": "kyle"]))
-      try expect(result) == "KYLE"
-    }
-  }
-
-  describe("lowercase filter") {
-    let template = Template(templateString: "{{ name|lowercase }}")
-
-    $0.it("transforms a string to be lowercase") {
-      let result = try template.render(Context(dictionary: ["name": "Kyle"]))
-      try expect(result) == "kyle"
+      $0.it("transforms a string to be lowercase") {
+        let template = Template(templateString: "{{ names|lowercase }}")
+        let result = try template.render(Context(dictionary: ["names": ["Kyle", "Kyle"]]))
+        try expect(result) == "[\"kyle\", \"kyle\"]"
+      }
     }
   }
 


### PR DESCRIPTION
Together with #189 this will allow to map and apply filters to mapped values, i.e. `for name in users|map:"name"|uppercased`