### PR TITLE
Implemented parsing of range literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added support for iterating arrays of tuples
 - Added support for ranges in if-in expression
 - Added property `forloop.length` to get number of items in the loop
+- Now you can construct ranges for loops using `a...b` syntax, i.e. `for i in 1...array.count`
 
 ### Bug Fixes
 

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -10,17 +10,21 @@ class ForNode : NodeType {
   class func parse(_ parser:TokenParser, token:Token) throws -> NodeType {
     let components = token.components()
 
-    guard components.count >= 3 && components[2] == "in" &&
-        (components.count == 4 || (components.count >= 6 && components[4] == "where")) else {
-      throw TemplateSyntaxError("'for' statements should use the following 'for x in y where condition' `\(token.contents)`.")
+    func hasToken(_ token: String, at index: Int) -> Bool {
+      return components.count > (index + 1) && components[index] == token
+    }
+    func endsOrHasToken(_ token: String, at index: Int) -> Bool {
+      return components.count == index || hasToken(token, at: index)
+    }
+
+    guard hasToken("in", at: 2) && endsOrHasToken("where", at: 4) else {
+      throw TemplateSyntaxError("'for' statements should use the syntax: `for <x> in <y> [where <condition>]")
     }
 
     let loopVariables = components[1].characters
       .split(separator: ",")
       .map(String.init)
       .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
-
-    let variable = components[3]
 
     var emptyNodes = [NodeType]()
 
@@ -35,14 +39,13 @@ class ForNode : NodeType {
       _ = parser.nextToken()
     }
 
-    let filter = try parser.compileFilter(variable)
-    let `where`: Expression?
-    if components.count >= 6 {
-      `where` = try parseExpression(components: Array(components.suffix(from: 5)), tokenParser: parser)
-    } else {
-      `where` = nil
-    }
-    return ForNode(resolvable: filter, loopVariables: loopVariables, nodes: forNodes, emptyNodes:emptyNodes, where: `where`)
+    let resolvable = try parser.compileResolvable(components[3])
+
+    let `where` = hasToken("where", at: 4)
+      ? try parseExpression(components: Array(components.suffix(from: 5)), tokenParser: parser)
+      : nil
+
+    return ForNode(resolvable: resolvable, loopVariables: loopVariables, nodes: forNodes, emptyNodes:emptyNodes, where: `where`)
   }
 
   init(resolvable: Resolvable, loopVariables: [String], nodes:[NodeType], emptyNodes:[NodeType], where: Expression? = nil) {

--- a/Sources/IfTag.swift
+++ b/Sources/IfTag.swift
@@ -111,7 +111,7 @@ final class IfExpressionParser {
         }
       }
 
-      return .variable(try tokenParser.compileFilter(component))
+      return .variable(try tokenParser.compileResolvable(component))
     }
   }
 

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -40,7 +40,7 @@ public class TokenParser {
       case .text(let text):
         nodes.append(TextNode(text: text))
       case .variable:
-        nodes.append(VariableNode(variable: try compileFilter(token.contents)))
+        nodes.append(VariableNode(variable: try compileResolvable(token.contents)))
       case .block:
         if let parse_until = parse_until , parse_until(self, token) {
           prependToken(token)
@@ -112,6 +112,11 @@ public class TokenParser {
 
   public func compileFilter(_ token: String) throws -> Resolvable {
     return try FilterExpression(token: token, parser: self)
+  }
+
+  public func compileResolvable(_ token: String) throws -> Resolvable {
+    return try RangeVariable(token, parser: self)
+      ?? compileFilter(token)
   }
 
 }

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -227,7 +227,7 @@ func testForNode() {
           .block(value: "for i"),
       ]
       let parser = TokenParser(tokens: tokens, environment: Environment())
-      let error = TemplateSyntaxError("'for' statements should use the following 'for x in y where condition' `for i`.")
+      let error = TemplateSyntaxError("'for' statements should use the syntax: `for <x> in <y> [where <condition>]")
       try expect(try parser.parse()).toThrow(error)
     }
 
@@ -304,6 +304,11 @@ func testForNode() {
       let result = try node.render(context)
 
       try expect(result) == "childString=child\nbaseString=base\nbaseInt=1\n"
+    }
+
+    $0.it("can iterate in range of variables") {
+      let template: Template = "{% for i in 1...j %}{{ i }}{% endfor %}"
+      try expect(try template.render(Context(dictionary: ["j": 3]))) == "123"
     }
 
   }

--- a/Tests/StencilTests/IfNodeSpec.swift
+++ b/Tests/StencilTests/IfNodeSpec.swift
@@ -270,5 +270,22 @@ func testIfNode() {
       let result = try renderNodes(nodes, Context(dictionary: ["instance": SomeType()]))
       try expect(result) == ""
     }
+
+    $0.it("supports closed range variables") {
+      let tokens: [Token] = [
+        .block(value: "if value in 1...3"),
+        .text(value: "true"),
+        .block(value: "else"),
+        .text(value: "false"),
+        .block(value: "endif")
+      ]
+
+      let parser = TokenParser(tokens: tokens, environment: Environment())
+      let nodes = try parser.parse()
+
+      try expect(renderNodes(nodes, Context(dictionary: ["value": 3]))) == "true"
+      try expect(renderNodes(nodes, Context(dictionary: ["value": 4]))) == "false"
+    }
+
   }
 }


### PR DESCRIPTION
This is alternative implementation of #179 that does not introduce new syntax for loops and automatically supports if-in expressions.
If we merge #175 we could even support open ranges, but for now only closed ranges are supported.

Closes #179 
Closes https://github.com/SwiftGen/StencilSwiftKit/issues/74