### PR TITLE
Allow using new lines inside tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Allow default string filters to be applied to arrays
 - Similar filters are suggested when unknown filter is used
 - Added `indent` filter
+- Allow using new lines inside tags
 
 ### Bug Fixes
 

--- a/Sources/Lexer.swift
+++ b/Sources/Lexer.swift
@@ -10,7 +10,12 @@ struct Lexer {
       guard string.characters.count > 4 else { return "" }
       let start = string.index(string.startIndex, offsetBy: 2)
       let end = string.index(string.endIndex, offsetBy: -2)
-      return String(string[start..<end]).trim(character: " ")
+      let trimmed = String(string[start..<end])
+        .components(separatedBy: "\n")
+        .filter({ !$0.isEmpty })
+        .map({ $0.trim(character: " ") })
+        .joined(separator: " ")
+      return trimmed
     }
 
     if string.hasPrefix("{{") {

--- a/Tests/StencilTests/LexerSpec.swift
+++ b/Tests/StencilTests/LexerSpec.swift
@@ -64,5 +64,27 @@ func testLexer() {
       let lexer = Lexer(templateString: "{{}}")
       let _ = lexer.tokenize()
     }
+
+    $0.it("can tokenize with new lines") {
+        let lexer = Lexer(templateString:
+        "My name is {%\n" +
+        "    if name\n" +
+        "     and\n" +
+        "    name\n" +
+        "%}{{\n" +
+        "name\n" +
+        "}}{%\n" +
+        "endif %}.")
+
+        let tokens = lexer.tokenize()
+
+        try expect(tokens.count) == 5
+        try expect(tokens[0]) == Token.text(value: "My name is ")
+        try expect(tokens[1]) == Token.block(value: "if name and name")
+        try expect(tokens[2]) == Token.variable(value: "name")
+        try expect(tokens[3]) == Token.block(value: "endif")
+        try expect(tokens[4]) == Token.text(value: ".")
+
+    }
   }
 }

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -5,10 +5,10 @@ import Spectre
 
 #if os(OSX)
 @objc class Superclass: NSObject {
-  let name = "Foo"
+  @objc let name = "Foo"
 }
 @objc class Object : Superclass {
-  let title = "Hello World"
+  @objc let title = "Hello World"
 }
 #endif
 


### PR DESCRIPTION
To make templates more readable this allows using new lines in tags (anywhere where spaces are allowed), which can be useful when dealing with really long conditions to break them into several lines.

```jinja
        There are {{ articles.count }} articles.

        {% for article in articles 
                          where 
                          article.length > 100 and
                          article.author.name and
                          article.comments.count > 0
        %}    - {{ article.title }} by {{ article.author }}.
        {% endfor %}
```