### PR TITLE
Do not print Optionl(...) when rendering arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed comparing string variables with string literals, in Swift 4 string literals became `Substring` and thus couldn't be directly compared to strings.
 - Integer literals now resolve into Int values, not Float
 - Fixed accessing properties of optional properties via reflection
+- No longer render optional values in arrays as `Optional(..)`
 
 
 ## 0.10.1

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -78,6 +78,8 @@ public class VariableNode : NodeType {
 func stringify(_ result: Any?) -> String {
   if let result = result as? String {
     return result
+  } else if let array = result as? [Any?] {
+    return unwrap(array).description
   } else if let result = result as? CustomStringConvertible {
     return result.description
   } else if let result = result as? NSObject {
@@ -85,4 +87,17 @@ func stringify(_ result: Any?) -> String {
   }
 
   return ""
+}
+
+func unwrap(_ array: [Any?]) -> [Any] {
+  return array.map { (item: Any?) -> Any in
+    if let item = item {
+      if let items = item as? [Any?] {
+        return unwrap(items)
+      } else {
+        return item
+      }
+    }
+    else { return item as Any }
+  }
 }

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -148,7 +148,7 @@ func testVariable() {
       try expect(result) == "Foo"
     }
 #endif
-    
+
     $0.it("can resolve a value via reflection") {
       let variable = Variable("blog.articles.0.author.name")
       let result = try variable.resolve(context) as? String
@@ -167,5 +167,13 @@ func testVariable() {
       try expect(result) == "Jhon"
     }
 
+    $0.it("does not render Optional") {
+      var array: [Any?] = [1, nil]
+      array.append(array)
+      let context = Context(dictionary: ["values": array])
+
+      try expect(VariableNode(variable: "values").render(context)) == "[1, nil, [1, nil]]"
+      try expect(VariableNode(variable: "values.1").render(context)) == ""
+    }
   }
 }


### PR DESCRIPTION
Currently when rendering arrays of optional properties non-nil values will be rendered to `Optional(...)` instead of just printing value.