### PR TITLE
fixed using quote as a single parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Stencil Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixed using quote as a filter parameter
+
+
 ## 0.11.0 (2018-04-04)
 
 ### Enhancements

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -18,7 +18,7 @@ extension String {
 
         if separate != separator {
           word.append(separate)
-        } else if singleQuoteCount % 2 == 0 && doubleQuoteCount % 2 == 0 && !word.isEmpty {
+        } else if (singleQuoteCount % 2 == 0 || doubleQuoteCount % 2 == 0) && !word.isEmpty {
           components.append(word)
           word = ""
         }

--- a/Tests/StencilTests/FilterTagSpec.swift
+++ b/Tests/StencilTests/FilterTagSpec.swift
@@ -30,5 +30,16 @@ func testFilterTag() {
       let result = try env.renderTemplate(string: "{% filter split:\",\"|join:\";\"  %}{{ items|join:\",\" }}{% endfilter %}", context: ["items": [1, 2]])
       try expect(result) == "1;2"
     }
+
+    $0.it("can render filters with quote as an argument") {
+        let ext = Extension()
+        ext.registerFilter("replace", filter: {
+            print($1[0] as! String)
+            return ($0 as! String).replacingOccurrences(of: $1[0] as! String, with: $1[1] as! String)
+        })
+        let env = Environment(extensions: [ext])
+        let result = try env.renderTemplate(string: "{% filter replace:'\"',\"\" %}{{ items|join:\",\" }}{% endfilter %}", context: ["items": ["\"1\"", "\"2\""]])
+        try expect(result) == "1,2"
+    }
   }
 }


### PR DESCRIPTION
Resolves #209 